### PR TITLE
Revamp Mapbox weather control panel UI

### DIFF
--- a/apps/mapbox-weather-vis/src/components/Mapbox.vue
+++ b/apps/mapbox-weather-vis/src/components/Mapbox.vue
@@ -6,15 +6,30 @@
     <ThreeParticlesOverlay v-else />
     <RadarOverlay :active="uiState.radarOn" :opacity="uiState.radarOpacity" />
 
-    <div class="ui-overlay" role="region" aria-label="Map controls">
-      <div class="panel">
-        <h2 class="panel-title">Map Controls</h2>
-        <StyleSelector />
-        <LayerToggle />
-        <RadarControl />
-        <EffectSelector />
-        <TimeControl />
-      </div>
+    <div class="ui-overlay" role="region" aria-labelledby="map-controls-title">
+      <section class="panel">
+        <header class="panel-header">
+          <p class="panel-eyebrow">Weather layers</p>
+          <h2 id="map-controls-title" class="panel-title">Map Controls</h2>
+        </header>
+        <div class="panel-content">
+          <div class="panel-section">
+            <StyleSelector />
+          </div>
+          <div class="panel-section">
+            <LayerToggle />
+          </div>
+          <div class="panel-section">
+            <RadarControl />
+          </div>
+          <div class="panel-section">
+            <EffectSelector />
+          </div>
+          <div class="panel-section">
+            <TimeControl />
+          </div>
+        </div>
+      </section>
     </div>
   </div>
 </template>
@@ -124,25 +139,66 @@ function applyLabelVisibility(m: mapboxgl.Map, visible: boolean) {
 }
 .ui-overlay {
   position: absolute;
-  top: 0.75rem;
-  left: 0.75rem;
+  top: 1.25rem;
+  left: 1.25rem;
   z-index: 10;
   display: flex;
   gap: 0.75rem;
+  align-items: flex-start;
 }
 .panel {
-  min-width: 240px;
-  max-width: 320px;
-  background: rgba(255, 255, 255, 0.9);
-  border-radius: 10px;
-  box-shadow: 0 4px 16px rgba(2, 6, 23, 0.2);
-  padding: 0.75rem;
-  backdrop-filter: blur(6px);
+  min-width: 260px;
+  max-width: min(360px, calc(100vw - 2.5rem));
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: 18px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.35);
+  padding: 1.25rem;
+  backdrop-filter: blur(18px) saturate(140%);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: #e2e8f0;
+}
+.panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+}
+.panel-eyebrow {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
 }
 .panel-title {
-  margin: 0 0 0.5rem 0;
-  font-size: 0.95rem;
+  margin: 0;
+  font-size: 1.25rem;
   font-weight: 600;
-  color: #0f172a;
+  color: #f8fafc;
+}
+.panel-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.panel-section {
+  border-radius: 14px;
+  padding: 0.85rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 1px 0 rgba(226, 232, 240, 0.05);
+}
+
+@media (max-width: 768px) {
+  .ui-overlay {
+    top: 1rem;
+    left: 1rem;
+    right: 1rem;
+  }
+
+  .panel {
+    width: 100%;
+    max-width: none;
+  }
 }
 </style>

--- a/apps/mapbox-weather-vis/src/components/controls/EffectSelector.vue
+++ b/apps/mapbox-weather-vis/src/components/controls/EffectSelector.vue
@@ -12,20 +12,69 @@ function onChange(e: Event) {
 </script>
 
 <template>
-  <fieldset class="control">
-    <label class="label" for="effect">Particle effect</label>
-    <select id="effect" class="select" :value="uiState?.effect" @change="onChange">
-      <option value="off">Off (2D demo)</option>
-      <option value="wind">Wind (3D)</option>
-      <option value="rain">Rain (3D)</option>
-      <option value="snow">Snow (3D)</option>
-    </select>
+  <fieldset class="control-card">
+    <label class="control-label" for="effect">Particle effect</label>
+    <div class="control-field">
+      <select id="effect" class="control-select" :value="uiState?.effect" @change="onChange">
+        <option value="off">Off (2D demo)</option>
+        <option value="wind">Wind (3D)</option>
+        <option value="rain">Rain (3D)</option>
+        <option value="snow">Snow (3D)</option>
+      </select>
+      <span class="select-caret" aria-hidden="true">⌄</span>
+    </div>
   </fieldset>
 </template>
 
 <style scoped>
-.control { margin-bottom: 0.5rem; display: grid; gap: 0.25rem; }
-.label { font-size: 0.8rem; color: #334155; }
-.select { width: 100%; padding: 0.4rem 0.5rem; border: 1px solid #e2e8f0; border-radius: 8px; background: white; }
+.control-card {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+.control-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.8);
+}
+.control-field {
+  position: relative;
+}
+.control-select {
+  appearance: none;
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  padding-right: 2.2rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: #f8fafc;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.4);
+}
+.control-select:focus-visible {
+  outline: none;
+  border-color: rgba(129, 140, 248, 0.85);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+}
+.control-select option {
+  color: #0f172a;
+}
+.select-caret {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.7);
+}
 </style>
 

--- a/apps/mapbox-weather-vis/src/components/controls/LayerToggle.vue
+++ b/apps/mapbox-weather-vis/src/components/controls/LayerToggle.vue
@@ -42,16 +42,101 @@ watch(
 </script>
 
 <template>
-  <fieldset class="control">
-    <label class="checkbox">
-      <input type="checkbox" :checked="uiState?.showLabels" @change="onToggleLabels" />
-      <span>Show labels</span>
-    </label>
+  <fieldset class="control-card">
+    <legend class="sr-only">Toggle map labels</legend>
+    <div class="switch">
+      <div class="switch-copy">
+        <span class="switch-title">Show labels</span>
+        <span class="switch-subtitle">Reveal place names and road markers</span>
+      </div>
+      <label class="switch-control">
+        <input class="switch-input" type="checkbox" :checked="uiState?.showLabels" @change="onToggleLabels" />
+        <span class="switch-track" aria-hidden="true">
+          <span class="switch-handle"></span>
+        </span>
+      </label>
+    </div>
   </fieldset>
 </template>
 
 <style scoped>
-.control { margin-bottom: 0.5rem; }
-.checkbox { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9rem; color: #0f172a; }
-input[type="checkbox"] { width: 16px; height: 16px; }
+.control-card {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.switch {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+.switch-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.switch-title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #f8fafc;
+}
+.switch-subtitle {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+.switch-control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+.switch-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.switch-track {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.switch-handle {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #f8fafc;
+  transform: translateX(0);
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s ease;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.45);
+}
+.switch-control:focus-within .switch-track {
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.35);
+}
+.switch-input:checked + .switch-track {
+  background: rgba(96, 165, 250, 0.55);
+  border-color: rgba(59, 130, 246, 0.7);
+}
+.switch-input:checked + .switch-track .switch-handle {
+  transform: translateX(20px);
+  background: #0f172a;
+}
 </style>

--- a/apps/mapbox-weather-vis/src/components/controls/RadarControl.vue
+++ b/apps/mapbox-weather-vis/src/components/controls/RadarControl.vue
@@ -17,24 +17,173 @@ function onOpacity(e: Event) {
 </script>
 
 <template>
-  <fieldset class="control">
-    <label class="checkbox">
-      <input type="checkbox" :checked="uiState?.radarOn" @change="onToggle" />
-      <span>Radar (RainViewer)</span>
-    </label>
-    <div class="row" :aria-disabled="!uiState?.radarOn">
-      <label class="label" for="radarOpacity">Opacity</label>
-      <input id="radarOpacity" class="range" type="range" min="0" max="1" step="0.05" :value="uiState?.radarOpacity" @input="onOpacity" />
+  <fieldset class="control-card">
+    <legend class="control-legend">
+      <div class="legend-copy">
+        <span class="legend-title">Radar overlay</span>
+        <span class="legend-subtitle">RainViewer reflectivity</span>
+      </div>
+      <label class="toggle">
+        <input class="toggle-input" type="checkbox" :checked="uiState?.radarOn" @change="onToggle" />
+        <span class="toggle-track" aria-hidden="true">
+          <span class="toggle-handle"></span>
+        </span>
+      </label>
+    </legend>
+    <div class="slider" :data-disabled="!uiState?.radarOn">
+      <label class="slider-label" for="radarOpacity">Opacity</label>
+      <input
+        id="radarOpacity"
+        class="slider-input"
+        type="range"
+        min="0"
+        max="1"
+        step="0.05"
+        :value="uiState?.radarOpacity"
+        :disabled="!uiState?.radarOn"
+        @input="onOpacity"
+      />
+      <span class="slider-value">{{ Math.round(((uiState?.radarOpacity ?? 0) * 100)) }}%</span>
     </div>
   </fieldset>
 </template>
 
 <style scoped>
-.control { margin-bottom: 0.5rem; display: grid; gap: 0.25rem; }
-.checkbox { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9rem; color: #0f172a; }
-.row { display: grid; grid-template-columns: auto 1fr; align-items: center; gap: 0.5rem; opacity: 1; }
-[aria-disabled="true"] { opacity: 0.5; }
-.label { font-size: 0.8rem; color: #334155; }
-.range { width: 100%; }
+.control-card {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+.control-legend {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.legend-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+.legend-title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #f8fafc;
+}
+.legend-subtitle {
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.68);
+}
+.toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+.toggle-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.toggle-track {
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.toggle-handle {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #f8fafc;
+  transform: translateX(0);
+  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.2s ease;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.45);
+}
+.toggle:focus-within .toggle-track {
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+.toggle-input:checked + .toggle-track {
+  background: rgba(96, 165, 250, 0.55);
+  border-color: rgba(59, 130, 246, 0.7);
+}
+.toggle-input:checked + .toggle-track .toggle-handle {
+  transform: translateX(20px);
+  background: #0f172a;
+}
+.slider {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  transition: opacity 0.2s ease;
+}
+.slider[data-disabled="true"] {
+  opacity: 0.5;
+}
+.slider-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.7);
+}
+.slider-input {
+  width: 100%;
+  accent-color: #60a5fa;
+}
+.slider-input:disabled {
+  accent-color: rgba(148, 163, 184, 0.5);
+}
+.slider-input::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.4);
+}
+.slider-input::-webkit-slider-thumb {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: #f8fafc;
+  border: 2px solid #60a5fa;
+  margin-top: -4px;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.4);
+}
+.slider-input:disabled::-webkit-slider-thumb {
+  border-color: rgba(148, 163, 184, 0.6);
+  background: rgba(226, 232, 240, 0.8);
+}
+.slider-input::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.4);
+}
+.slider-input::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: #f8fafc;
+  border: 2px solid #60a5fa;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.4);
+}
+.slider-input:disabled::-moz-range-thumb {
+  border-color: rgba(148, 163, 184, 0.6);
+  background: rgba(226, 232, 240, 0.8);
+}
+.slider-value {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.85rem;
+  color: #f1f5f9;
+}
 </style>
 

--- a/apps/mapbox-weather-vis/src/components/controls/StyleSelector.vue
+++ b/apps/mapbox-weather-vis/src/components/controls/StyleSelector.vue
@@ -29,22 +29,71 @@ watch(
 </script>
 
 <template>
-  <fieldset class="control">
-    <label class="label" for="style">Base map style</label>
-    <select id="style" class="select" :value="uiState?.styleId" @change="onChange">
-      <option value="mapbox://styles/mapbox/streets-v12">Streets</option>
-      <option value="mapbox://styles/mapbox/outdoors-v12">Outdoors</option>
-      <option value="mapbox://styles/mapbox/light-v11">Light</option>
-      <option value="mapbox://styles/mapbox/dark-v11">Dark</option>
-      <option value="mapbox://styles/mapbox/satellite-streets-v12">Satellite</option>
-      <option value="mapbox://styles/mapbox/standard">Standard</option>
-    </select>
+  <fieldset class="control-card">
+    <label class="control-label" for="style">Base map style</label>
+    <div class="control-field">
+      <select id="style" class="control-select" :value="uiState?.styleId" @change="onChange">
+        <option value="mapbox://styles/mapbox/streets-v12">Streets</option>
+        <option value="mapbox://styles/mapbox/outdoors-v12">Outdoors</option>
+        <option value="mapbox://styles/mapbox/light-v11">Light</option>
+        <option value="mapbox://styles/mapbox/dark-v11">Dark</option>
+        <option value="mapbox://styles/mapbox/satellite-streets-v12">Satellite</option>
+        <option value="mapbox://styles/mapbox/standard">Standard</option>
+      </select>
+      <span class="select-caret" aria-hidden="true">⌄</span>
+    </div>
   </fieldset>
-  
+
 </template>
 
 <style scoped>
-.control { margin-bottom: 0.5rem; display: grid; gap: 0.25rem; }
-.label { font-size: 0.8rem; color: #334155; }
-.select { width: 100%; padding: 0.4rem 0.5rem; border: 1px solid #e2e8f0; border-radius: 8px; background: white; }
+.control-card {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+.control-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.8);
+}
+.control-field {
+  position: relative;
+}
+.control-select {
+  appearance: none;
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  padding-right: 2.2rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
+  color: #f8fafc;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.4);
+}
+.control-select:focus-visible {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.8);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+  background: rgba(15, 23, 42, 0.65);
+}
+.control-select option {
+  color: #0f172a;
+}
+.select-caret {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.7);
+}
 </style>

--- a/apps/mapbox-weather-vis/src/components/controls/TimeControl.vue
+++ b/apps/mapbox-weather-vis/src/components/controls/TimeControl.vue
@@ -44,20 +44,147 @@ const timeLabel = () => (uiState ? Math.round(uiState.time) : 0)
 </script>
 
 <template>
-  <fieldset class="control">
-    <div class="row">
-      <button class="btn" type="button" @click="togglePlay">{{ uiState?.playing ? 'Pause' : 'Play' }}</button>
-      <div class="time">t = {{ timeLabel() }}</div>
-    </div>
-    <input class="range" type="range" min="0" max="100" step="0.5" :value="uiState?.time" @input="onInput" />
+  <fieldset class="control-card">
+    <legend class="control-legend">
+      <span class="legend-title">Simulation time</span>
+      <button
+        class="play-btn"
+        type="button"
+        :aria-pressed="uiState?.playing ? 'true' : 'false'"
+        :class="{ 'is-active': uiState?.playing }"
+        @click="togglePlay"
+      >
+        <span class="play-icon" aria-hidden="true"></span>
+        {{ uiState?.playing ? 'Pause' : 'Play' }}
+      </button>
+    </legend>
+    <div class="time-readout">t = {{ timeLabel() }}</div>
+    <input
+      class="time-slider"
+      type="range"
+      min="0"
+      max="100"
+      step="0.5"
+      :value="uiState?.time"
+      @input="onInput"
+    />
   </fieldset>
 </template>
 
 <style scoped>
-.control { margin-top: 0.5rem; display: grid; gap: 0.5rem; }
-.row { display: flex; align-items: center; gap: 0.5rem; }
-.btn { padding: 0.35rem 0.6rem; border: 1px solid #cbd5e1; border-radius: 6px; background: #fff; cursor: pointer; }
-.btn:hover { background: #f8fafc; }
-.time { font-size: 0.9rem; color: #334155; }
-.range { width: 100%; }
+.control-card {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+.control-legend {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.legend-title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #f8fafc;
+}
+.play-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.55);
+  color: #f8fafc;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.play-btn:hover {
+  background: rgba(96, 165, 250, 0.25);
+  border-color: rgba(96, 165, 250, 0.6);
+}
+.play-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+.play-btn.is-active {
+  background: rgba(96, 165, 250, 0.35);
+  border-color: rgba(59, 130, 246, 0.75);
+}
+.play-icon {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 2px;
+  position: relative;
+  display: inline-block;
+}
+.play-btn:not(.is-active) .play-icon {
+  border-style: solid;
+  border-width: 0.3rem 0 0.3rem 0.5rem;
+  border-color: transparent transparent transparent currentColor;
+}
+.play-btn.is-active .play-icon {
+  width: 0.7rem;
+  height: 0.7rem;
+}
+.play-btn.is-active .play-icon::before,
+.play-btn.is-active .play-icon::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0.2rem;
+  background: currentColor;
+  border-radius: 1px;
+}
+.play-btn.is-active .play-icon::before {
+  left: 0;
+}
+.play-btn.is-active .play-icon::after {
+  right: 0;
+}
+.time-readout {
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+.time-slider {
+  width: 100%;
+  accent-color: #38bdf8;
+}
+.time-slider::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.4);
+}
+.time-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: #f8fafc;
+  border: 2px solid #38bdf8;
+  margin-top: -4px;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.4);
+}
+.time-slider::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.4);
+}
+.time-slider::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: #f8fafc;
+  border: 2px solid #38bdf8;
+  box-shadow: 0 1px 4px rgba(15, 23, 42, 0.4);
+}
 </style>


### PR DESCRIPTION
## Summary
- restyle the map control overlay with a glassmorphism-inspired panel and clearer section layout
- refresh each weather control with consistent typography, custom toggles, and enhanced slider/button styling

## Testing
- npm run build *(fails: vue-tsc cannot find bundled typescript dependency in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cab5741b34832f9bc72ba4e08c0b30