### PR TITLE
refactor: improve vue components typing and safety

### DIFF
--- a/apps/mapbox-pokemon-battler/src/App.vue
+++ b/apps/mapbox-pokemon-battler/src/App.vue
@@ -27,7 +27,10 @@ onMounted(() => {
   window.addEventListener('pointermove', motionHandler, { passive: true })
 })
 onBeforeUnmount(() => {
-  if (motionHandler) window.removeEventListener('pointermove', motionHandler as any)
+  if (motionHandler) {
+    window.removeEventListener('pointermove', motionHandler)
+    motionHandler = null
+  }
 })
 </script>
 

--- a/apps/mapbox-pokemon-battler/src/components/battle/BattleOverlay.vue
+++ b/apps/mapbox-pokemon-battler/src/components/battle/BattleOverlay.vue
@@ -97,6 +97,14 @@ const myHpPercent = computed(() => {
   return Math.max(0, (playerState.value.currentHp / playerState.value.maxHp) * 100)
 })
 
+const playerSpriteUrl = computed(() => {
+  const sprites = playerState.value?.instance.sprites
+  if (!sprites) return ''
+  return sprites.back_default || sprites.front_default || ''
+})
+
+const shouldFlipPlayerSprite = computed(() => !playerState.value?.instance.sprites.back_default)
+
 watch(playerState, async (v) => {
   if (v) {
     anim.playerEnter = false
@@ -127,7 +135,8 @@ function getTypes(p: PokemonInstance): string[] {
 }
 
 function buildBattler(p: PokemonInstance): BattlerState {
-  const stats = Object.fromEntries((p.stats || []).map((s: any) => [s.stat.name, s.base_stat])) as Record<string, number>
+  const statEntries = (p.stats ?? []).map((s) => [s.stat.name, s.base_stat] as const)
+  const stats = Object.fromEntries(statEntries) as Record<string, number>
   const level = p.level ?? 5
   const baseHp = stats.hp ?? 45
   const baseAtk = stats.attack ?? 49
@@ -455,8 +464,8 @@ initBattle()
             <div class="hptext">{{ playerState.currentHp }} / {{ playerState.maxHp }}</div>
           </div>
           <div class="platform platform-me"></div>
-          <img :src="(playerState.instance.sprites as any)?.back_default || playerState.instance.sprites.front_default"
-               :class="{ 'me-sprite': true, 'sprite': true, 'flipped': !(playerState.instance.sprites as any)?.back_default, 'enter-me': anim.playerEnter, 'hit': anim.playerHit }"
+          <img :src="playerSpriteUrl"
+               :class="{ 'me-sprite': true, 'sprite': true, flipped: shouldFlipPlayerSprite, 'enter-me': anim.playerEnter, 'hit': anim.playerHit }"
                alt="me" />
         </div>
       </div>

--- a/apps/mapbox-pokemon-battler/src/components/pokemon/PokemonInspect.vue
+++ b/apps/mapbox-pokemon-battler/src/components/pokemon/PokemonInspect.vue
@@ -7,7 +7,8 @@ const props = defineProps<{ pokemon: PokemonInstance }>()
 const emit = defineEmits(['close', 'set-active'])
 
 function spriteUrl() {
-  return (props.pokemon.sprites as any)?.other?.['official-artwork']?.front_default || props.pokemon.sprites.front_default
+  const sprites = props.pokemon.sprites
+  return sprites.other?.['official-artwork']?.front_default || sprites.front_default || ''
 }
 
 function typeList() {

--- a/apps/mapbox-pokemon-battler/src/services/pokeapi.ts
+++ b/apps/mapbox-pokemon-battler/src/services/pokeapi.ts
@@ -1,7 +1,9 @@
+import type { PokemonSprites } from '../store'
+
 export type PokeBasic = {
   id: number
   name: string
-  sprites: { front_default?: string }
+  sprites: PokemonSprites
   types: { type: { name: string } }[]
   stats: { base_stat: number; stat: { name: string } }[]
 }

--- a/apps/mapbox-pokemon-battler/src/store.ts
+++ b/apps/mapbox-pokemon-battler/src/store.ts
@@ -1,9 +1,21 @@
 import { reactive } from 'vue'
 
+export type OfficialArtwork = {
+  front_default?: string | null
+}
+
+export type PokemonSprites = {
+  front_default?: string | null
+  back_default?: string | null
+  other?: {
+    ['official-artwork']?: OfficialArtwork | null
+  } | null
+}
+
 export type PokemonBasic = {
   id: number
   name: string
-  sprites: { front_default?: string }
+  sprites: PokemonSprites
   types: { type: { name: string } }[]
   stats?: { base_stat: number; stat: { name: string } }[]
 }

--- a/apps/mapbox-pokemon-battler/src/views/BattleView.vue
+++ b/apps/mapbox-pokemon-battler/src/views/BattleView.vue
@@ -1,22 +1,31 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { useStore } from '../store'
+import { useStore, type PokemonInstance } from '../store'
 import { useRouter } from 'vue-router'
 
 const store = useStore()
 const router = useRouter()
 
-type Battler = { name: string; hp: number; maxHp: number; atk: number; def: number; type: string; sprite?: string }
+type Battler = {
+  name: string
+  hp: number
+  maxHp: number
+  atk: number
+  def: number
+  type: string
+  sprite?: string | null
+}
 
-function toBattler(p: any): Battler {
-  const stats = Object.fromEntries((p.stats || []).map((s: any) => [s.stat.name, s.base_stat])) as any
+function toBattler(p: PokemonInstance): Battler {
+  const statEntries = (p.stats ?? []).map((s) => [s.stat.name, s.base_stat] as const)
+  const stats = Object.fromEntries(statEntries) as Record<string, number>
   return {
     name: p.name,
     maxHp: Math.max(50, (stats.hp || 45) * 2),
     hp: Math.max(50, (stats.hp || 45) * 2),
     atk: Math.max(20, stats.attack || 49),
     def: Math.max(20, stats.defense || 49),
-    type: (p.types?.[0]?.type?.name) || 'normal',
+    type: p.types?.[0]?.type?.name || 'normal',
     sprite: p.sprites?.front_default,
   }
 }

--- a/apps/mapbox-weather-vis/src/components/controls/EffectSelector.vue
+++ b/apps/mapbox-weather-vis/src/components/controls/EffectSelector.vue
@@ -1,13 +1,18 @@
 <script setup lang="ts">
 import { inject } from 'vue'
-import { MapUiStateKey } from '../di/keys'
+import { MapUiStateKey, type MapEffect } from '../di/keys'
 
-type UiState = { effect: 'off' | 'wind' | 'rain' | 'snow' }
-const uiState = inject(MapUiStateKey, null) as unknown as UiState | null
+const uiState = inject(MapUiStateKey, null)
+const allowedEffects = ['off', 'wind', 'rain', 'snow'] as const satisfies readonly MapEffect[]
+
+function isMapEffect(value: string): value is MapEffect {
+  return (allowedEffects as readonly string[]).includes(value)
+}
 
 function onChange(e: Event) {
-  const v = (e.target as HTMLSelectElement).value as UiState['effect']
-  if (uiState) uiState.effect = v
+  const value = (e.target as HTMLSelectElement).value
+  if (!uiState || !isMapEffect(value)) return
+  uiState.effect = value
 }
 </script>
 

--- a/apps/mapbox-weather-vis/src/components/controls/RadarControl.vue
+++ b/apps/mapbox-weather-vis/src/components/controls/RadarControl.vue
@@ -2,8 +2,7 @@
 import { inject } from 'vue'
 import { MapUiStateKey } from '../di/keys'
 
-type UiState = { radarOn: boolean; radarOpacity: number }
-const uiState = inject(MapUiStateKey, null) as unknown as UiState | null
+const uiState = inject(MapUiStateKey, null)
 
 function onToggle(e: Event) {
   if (!uiState) return

--- a/apps/mapbox-weather-vis/src/components/controls/StyleSelector.vue
+++ b/apps/mapbox-weather-vis/src/components/controls/StyleSelector.vue
@@ -1,31 +1,18 @@
 <script setup lang="ts">
-import { inject, watch } from 'vue'
-import type mapboxgl from 'mapbox-gl'
+import { inject } from 'vue'
 import { MapboxKey, MapUiStateKey } from '../di/keys'
 
-type UiState = {
-  styleId: string
-}
-
-const map = inject(MapboxKey, null) as unknown as { value: mapboxgl.Map | null } | null
-const uiState = inject(MapUiStateKey, null) as unknown as UiState | null
+const map = inject(MapboxKey, null)
+const uiState = inject(MapUiStateKey, null)
 
 // When user changes style, apply to map
 function onChange(e: Event) {
   const next = (e.target as HTMLSelectElement).value
   if (!uiState) return
   uiState.styleId = next
-  const m = (map as any)?.value as mapboxgl.Map | null
-  if (m) m.setStyle(next)
+  const mapInstance = map?.value
+  if (mapInstance) mapInstance.setStyle(next)
 }
-
-// Keep select in sync if style changes externally
-watch(
-  () => (map as any)?.value?.getStyle()?.sprite,
-  () => {
-    // No-op placeholder for potential sync logic
-  }
-)
 </script>
 
 <template>

--- a/apps/mapbox-weather-vis/src/components/controls/TimeControl.vue
+++ b/apps/mapbox-weather-vis/src/components/controls/TimeControl.vue
@@ -1,13 +1,8 @@
 <script setup lang="ts">
-import { inject, onMounted, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, inject, onMounted, onBeforeUnmount, ref } from 'vue'
 import { MapUiStateKey } from '../di/keys'
 
-type UiState = {
-  time: number
-  playing: boolean
-}
-
-const uiState = inject(MapUiStateKey, null) as unknown as UiState | null
+const uiState = inject(MapUiStateKey, null)
 const rafId = ref<number | null>(null)
 
 function tick() {
@@ -37,10 +32,13 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  if (rafId.value) cancelAnimationFrame(rafId.value)
+  if (rafId.value) {
+    cancelAnimationFrame(rafId.value)
+    rafId.value = null
+  }
 })
 
-const timeLabel = () => (uiState ? Math.round(uiState.time) : 0)
+const timeLabel = computed(() => (uiState ? Math.round(uiState.time) : 0))
 </script>
 
 <template>
@@ -58,7 +56,7 @@ const timeLabel = () => (uiState ? Math.round(uiState.time) : 0)
         {{ uiState?.playing ? 'Pause' : 'Play' }}
       </button>
     </legend>
-    <div class="time-readout">t = {{ timeLabel() }}</div>
+    <div class="time-readout">t = {{ timeLabel }}</div>
     <input
       class="time-slider"
       type="range"

--- a/apps/mapbox-weather-vis/src/components/di/keys.ts
+++ b/apps/mapbox-weather-vis/src/components/di/keys.ts
@@ -1,3 +1,18 @@
-export const MapboxKey = Symbol('MapboxMap')
-export const MapUiStateKey = Symbol('MapUiState')
+import type { InjectionKey, ShallowRef } from 'vue'
+import type mapboxgl from 'mapbox-gl'
+
+export type MapEffect = 'off' | 'wind' | 'rain' | 'snow'
+
+export interface MapUiState {
+  styleId: string
+  showLabels: boolean
+  time: number
+  playing: boolean
+  effect: MapEffect
+  radarOn: boolean
+  radarOpacity: number
+}
+
+export const MapboxKey: InjectionKey<ShallowRef<mapboxgl.Map | null>> = Symbol('MapboxMap')
+export const MapUiStateKey: InjectionKey<MapUiState> = Symbol('MapUiState')
 

--- a/apps/mapbox-weather-vis/src/components/overlays/WeatherParticlesCanvas.vue
+++ b/apps/mapbox-weather-vis/src/components/overlays/WeatherParticlesCanvas.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
-import { inject, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { inject, onBeforeUnmount, onMounted, ref } from 'vue'
 import type mapboxgl from 'mapbox-gl'
 import { MapboxKey, MapUiStateKey } from '../di/keys'
 
-type UiState = { time: number }
-
-const map = inject(MapboxKey, null) as unknown as { value: mapboxgl.Map | null } | null
-const uiState = inject(MapUiStateKey, null) as unknown as UiState | null
+const map = inject(MapboxKey, null)
+const uiState = inject(MapUiStateKey, null)
 
 const canvasEl = ref<HTMLCanvasElement | null>(null)
 const ctxRef = ref<CanvasRenderingContext2D | null>(null)
@@ -55,7 +53,7 @@ function step() {
   const h = canvas.clientHeight
 
   // Vary wind direction with time [0..100]
-  const t = (uiState?.time ?? 0) / 100 * Math.PI * 2
+  const t = ((uiState?.time ?? 0) / 100) * Math.PI * 2
   const windX = Math.cos(t) * 0.6
   const windY = Math.sin(t) * 0.3
 


### PR DESCRIPTION
## Summary
- type Vue dependency injection keys for the weather visualizer and tighten Mapbox control logic
- remove unsafe casts in weather overlays and controls while improving cleanup for events and timers
- expand Pokémon data typings and refactor battle/map views to compute sprites safely without `any`

## Testing
- `pnpm lint` *(fails: turbo binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb339cbe80832fa776dc56a1938927