### PR TITLE
Ensure spawns respect evolution levels

### DIFF
--- a/apps/mapbox-pokemon-battler/src/services/pokeapi.ts
+++ b/apps/mapbox-pokemon-battler/src/services/pokeapi.ts
@@ -6,11 +6,17 @@ export type PokeBasic = {
   sprites: PokemonSprites
   types: { type: { name: string } }[]
   stats: { base_stat: number; stat: { name: string } }[]
+  species: { name: string; url: string }
+  minLevel?: number | null
 }
 
 const API = 'https://pokeapi.co/api/v2'
 const memCache = new Map<string, any>()
 const pending = new Map<string, Promise<PokeBasic>>()
+const minLevelCache = new Map<string, number | null>()
+const minLevelPending = new Map<string, Promise<number | null>>()
+const evolutionChainCache = new Map<string, EvolutionChainResponse>()
+const evolutionChainPending = new Map<string, Promise<EvolutionChainResponse>>()
 const LS_NS = 'mpb_poke_v1_'
 const TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 
@@ -38,15 +44,107 @@ function writeCache(idOrName: number | string, value: any) {
   try { localStorage.setItem(k, JSON.stringify({ ts: Date.now(), data: value })) } catch {}
 }
 
+type EvolutionDetail = { min_level: number | null | undefined }
+type EvolutionChainLink = {
+  species: { name: string }
+  evolves_to: EvolutionChainLink[]
+  evolution_details: EvolutionDetail[]
+}
+type EvolutionChainResponse = { chain: EvolutionChainLink }
+
+async function fetchEvolutionChain(url: string): Promise<EvolutionChainResponse> {
+  if (evolutionChainCache.has(url)) return evolutionChainCache.get(url)!
+  if (evolutionChainPending.has(url)) return evolutionChainPending.get(url)!
+  const req = (async () => {
+    const res = await fetch(url, { cache: 'force-cache' as RequestCache })
+    if (!res.ok) throw new Error('Failed to fetch evolution chain')
+    const data = (await res.json()) as EvolutionChainResponse
+    evolutionChainCache.set(url, data)
+    return data
+  })()
+  evolutionChainPending.set(url, req)
+  try {
+    return await req
+  } finally {
+    evolutionChainPending.delete(url)
+  }
+}
+
+function extractMinLevelForSpecies(
+  node: EvolutionChainLink,
+  target: string,
+  incoming?: EvolutionDetail[]
+): number | null | undefined {
+  if (node.species?.name === target) {
+    const details = incoming ?? []
+    const levels = details
+      .map((d) => (typeof d?.min_level === 'number' ? d.min_level : null))
+      .filter((lvl): lvl is number => typeof lvl === 'number' && Number.isFinite(lvl))
+    if (!levels.length) return null
+    return Math.max(...levels)
+  }
+  for (const child of node.evolves_to ?? []) {
+    const result = extractMinLevelForSpecies(child, target, child.evolution_details)
+    if (result !== undefined) return result
+  }
+  return undefined
+}
+
+async function fetchSpeciesMinLevel(speciesName: string): Promise<number | null> {
+  if (!speciesName) return null
+  if (minLevelCache.has(speciesName)) return minLevelCache.get(speciesName) ?? null
+  if (minLevelPending.has(speciesName)) return minLevelPending.get(speciesName)!
+  const req = (async () => {
+    try {
+      const speciesRes = await fetch(`${API}/pokemon-species/${speciesName}`, {
+        cache: 'force-cache' as RequestCache,
+      })
+      if (!speciesRes.ok) throw new Error('Failed to fetch species')
+      const speciesData = (await speciesRes.json()) as {
+        evolution_chain?: { url?: string | null } | null
+      }
+      const chainUrl = speciesData.evolution_chain?.url
+      if (!chainUrl) return null
+      const chain = await fetchEvolutionChain(chainUrl)
+      const minLevel = extractMinLevelForSpecies(chain.chain, speciesName)
+      return typeof minLevel === 'number' ? minLevel : null
+    } catch {
+      return null
+    }
+  })()
+  minLevelPending.set(speciesName, req)
+  try {
+    const level = await req
+    minLevelCache.set(speciesName, level)
+    return level
+  } finally {
+    minLevelPending.delete(speciesName)
+  }
+}
+
 export async function fetchPokemon(idOrName: number | string): Promise<PokeBasic> {
   const cached = readCache(idOrName)
-  if (cached) return cached as PokeBasic
+  if (cached) {
+    const result = cached as PokeBasic
+    if ((result.minLevel === undefined || result.minLevel === null) && result.species?.name) {
+      try {
+        result.minLevel = await fetchSpeciesMinLevel(result.species.name)
+        writeCache(idOrName, result)
+      } catch {}
+    }
+    return result
+  }
   const key = getCacheKey(idOrName)
   if (pending.has(key)) return pending.get(key)!
   const req = (async () => {
     const res = await fetch(`${API}/pokemon/${idOrName}`, { cache: 'force-cache' as RequestCache })
     if (!res.ok) throw new Error('Failed to fetch pokemon')
     const data = (await res.json()) as PokeBasic
+    try {
+      data.minLevel = await fetchSpeciesMinLevel(data.species?.name ?? '')
+    } catch {
+      data.minLevel = data.minLevel ?? null
+    }
     writeCache(idOrName, data)
     return data
   })()

--- a/apps/mapbox-pokemon-battler/src/store.ts
+++ b/apps/mapbox-pokemon-battler/src/store.ts
@@ -18,6 +18,8 @@ export type PokemonBasic = {
   sprites: PokemonSprites
   types: { type: { name: string } }[]
   stats?: { base_stat: number; stat: { name: string } }[]
+  species?: { name: string; url: string }
+  minLevel?: number | null
 }
 
 type Account = { username: string | null }
@@ -136,7 +138,16 @@ function generateMoves(types: string[], count = 4): Move[] {
 
 function toInstance(p: PokemonBasic, level?: number): PokemonInstance {
   const types = p.types?.map((t) => t.type.name) || ['normal']
-  const lvl = level ?? Math.max(3, Math.floor(3 + Math.random() * 15))
+  const fallback = Math.max(3, Math.floor(3 + Math.random() * 15))
+  const speciesMin = typeof p.minLevel === 'number' && Number.isFinite(p.minLevel) ? p.minLevel : null
+  let lvl = level ?? fallback
+  if (!level && speciesMin !== null) {
+    const min = Math.max(3, speciesMin)
+    const spread = Math.max(2, Math.round(min * 0.2))
+    const max = Math.min(100, min + spread)
+    lvl = min + Math.floor(Math.random() * (max - min + 1))
+  }
+  if (speciesMin !== null) lvl = Math.max(lvl, Math.max(3, speciesMin))
   return {
     ...p,
     level: lvl,


### PR DESCRIPTION
## Summary
- augment cached pokemon data with species metadata and computed minimum evolution levels
- reuse pokeapi evolution chains to derive the minimum level a species can appear
- clamp generated wild and caught pokemon levels so they never drop below their required evolution level

## Testing
- `pnpm --filter mapbox-pokemon-battler build` *(fails: missing TypeScript dependency in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb37847900832f81b3354bf81efbe5