### PR TITLE
feat: establish shared theme system

### DIFF
--- a/apps/daggerheart-statblock-builder/package.json
+++ b/apps/daggerheart-statblock-builder/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@my-monorepo/theme": "workspace:*",
     "@my-monorepo/ui": "workspace:*",
     "vue": "^3.5.18"
   },

--- a/apps/daggerheart-statblock-builder/src/App.vue
+++ b/apps/daggerheart-statblock-builder/src/App.vue
@@ -56,9 +56,3 @@ const {
   </div>
 </template>
 
-<style scoped>
-:root { --muted: #666; }
-@media (prefers-color-scheme: dark) {
-  :root { --muted: #aaa; }
-}
-</style>

--- a/apps/daggerheart-statblock-builder/src/components/Toolbar.vue
+++ b/apps/daggerheart-statblock-builder/src/components/Toolbar.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { toJSONBlob, toMarkdown, downloadBlob } from '../lib/exporters'
 import { hasSaved, clear } from '../lib/persist'
 import type { Enemy, Environment } from '../types'
 import type { Theme } from '../lib/theme'
+import { themeOptions } from '@my-monorepo/theme'
 import { openGlossary } from '../lib/glossaryState'
 import {
   AppButton,
@@ -58,6 +60,11 @@ function openDoc(which: 'srd' | 'license') {
   const url = which === 'srd' ? srdUrl : licenseUrl
   window.open(url, '_blank')
 }
+
+const themeItems = computed(() => [
+  { label: 'System', value: 'system', icon: 'palette' },
+  ...themeOptions.map((opt) => ({ label: opt.label, value: opt.value, icon: 'palette' as const }))
+])
 </script>
 
 <template>
@@ -105,13 +112,7 @@ function openDoc(which: 'srd' | 'license') {
       </AppDropdown>
 
       <AppDropdown
-        :items="[
-          {label:'System', value:'system', icon:'palette'},
-          {label:'Slate', value:'slate', icon:'palette'},
-          {label:'Parchment', value:'parchment', icon:'palette'},
-          {label:'Emerald', value:'emerald', icon:'palette'},
-          {label:'Midnight', value:'midnight', icon:'palette'}
-        ]"
+        :items="themeItems"
         button-title="Theme"
         align="right"
         @select="v => emit('update:theme', v as Theme)"

--- a/apps/daggerheart-statblock-builder/src/lib/theme.ts
+++ b/apps/daggerheart-statblock-builder/src/lib/theme.ts
@@ -1,23 +1,39 @@
-const THEME_KEY = 'dhsb:theme'
-export type Theme = 'system' | 'slate' | 'parchment' | 'emerald' | 'midnight'
+import {
+  applyTheme as applyCoreTheme,
+  readStoredTheme,
+  storeThemePreference,
+  type ThemeName
+} from '@my-monorepo/theme'
+
+const LEGACY_THEME_KEY = 'dhsb:theme'
+
+export type Theme = 'system' | ThemeName
+
+function readLegacyTheme(): Theme | null {
+  try {
+    const legacy = localStorage.getItem(LEGACY_THEME_KEY) as Theme | null
+    return legacy ?? null
+  } catch {
+    return null
+  }
+}
 
 export function getSavedTheme(): Theme {
-  try {
-    const t = localStorage.getItem(THEME_KEY) as Theme | null
-    return t ?? 'system'
-  } catch { return 'system' }
+  const stored = readStoredTheme()
+  if (stored) return stored
+  return readLegacyTheme() ?? 'system'
 }
 
 export function saveTheme(theme: Theme) {
-  try { localStorage.setItem(THEME_KEY, theme) } catch {}
+  if (theme === 'system') {
+    storeThemePreference('system')
+  } else {
+    storeThemePreference(theme)
+  }
+  try { localStorage.setItem(LEGACY_THEME_KEY, theme) } catch {}
 }
 
 export function applyTheme(theme: Theme) {
-  const el = document.documentElement
-  if (theme === 'system') {
-    el.removeAttribute('data-theme')
-  } else {
-    el.setAttribute('data-theme', theme)
-  }
+  applyCoreTheme(theme, { persist: false })
 }
 

--- a/apps/daggerheart-statblock-builder/src/style.css
+++ b/apps/daggerheart-statblock-builder/src/style.css
@@ -1,82 +1,83 @@
 @import "tailwindcss";
+@import "@my-monorepo/theme/styles.css";
 
-:root {
-  color-scheme: light dark;
-  --bg: #f6f7f9;
-  --fg: #0f172a;
-  --muted: #64748b;
-  --surface: #ffffff;
-  --surface-2: #f1f5f9;
-  --border: #e2e8f0;
-  --accent: #2563eb;
-  --accent-weak: #bfdbfe;
-  --enemy-accent: #dc2626;
-  --env-accent: #059669;
-  --btn-bg: #f8fafc;
-  --btn-fg: #0f172a;
-  --btn-border: #cbd5e1;
-  --link: #2563eb;
-}
-
-/* System dark (when no explicit theme is set) */
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme]) {
-    --bg: #0b0e14;
-    --fg: #e5e7eb;
-    --muted: #a3a3a3;
-    --surface: #0f172a;
-    --surface-2: #0b1220;
-    --border: #1f2937;
-    --accent: #60a5fa;
-    --accent-weak: #1d4ed8;
-    --enemy-accent: #f87171;
-    --env-accent: #34d399;
-    --btn-bg: #111827;
-    --btn-fg: #e5e7eb;
-    --btn-border: #374151;
-    --link: #60a5fa;
-  }
-}
-
-/* Slate theme */
-[data-theme='slate'] {
-  --bg: #f6f7f9; --fg:#0f172a; --muted:#64748b; --surface:#ffffff; --surface-2:#f1f5f9; --border:#e2e8f0; --accent:#2563eb; --accent-weak:#bfdbfe; --enemy-accent:#dc2626; --env-accent:#059669; --btn-bg:#f8fafc; --btn-fg:#0f172a; --btn-border:#cbd5e1; --link:#2563eb;
-}
-[data-theme='parchment'] {
-  --bg: #faf6ef; --fg:#3b2f1e; --muted:#7c6953; --surface:#fffaf0; --surface-2:#f5ecd7; --border:#e7dcc8; --accent:#a16207; --accent-weak:#facc15; --enemy-accent:#b45309; --env-accent:#059669; --btn-bg:#fff7e6; --btn-fg:#3b2f1e; --btn-border:#e7dcc8; --link:#9a3412;
-}
-[data-theme='emerald'] {
-  --bg: #ecfdf5; --fg:#064e3b; --muted:#065f46; --surface:#ffffff; --surface-2:#d1fae5; --border:#a7f3d0; --accent:#059669; --accent-weak:#6ee7b7; --enemy-accent:#dc2626; --env-accent:#059669; --btn-bg:#e6fffb; --btn-fg:#065f46; --btn-border:#99f6e4; --link:#047857;
-}
-[data-theme='midnight'] {
-  --bg: #0b1020; --fg:#e5e7eb; --muted:#a3a3a3; --surface:#0f172a; --surface-2:#0b1220; --border:#1f2937; --accent:#7c3aed; --accent-weak:#5b21b6; --enemy-accent:#f87171; --env-accent:#34d399; --btn-bg:#111827; --btn-fg:#e5e7eb; --btn-border:#374151; --link:#a78bfa;
-}
 html, body, #app { height: 100%; }
-body { margin: 0; background: var(--bg); color: var(--fg); font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
-button { border: 1px solid var(--btn-border); background: var(--btn-bg); color: var(--btn-fg); padding: .45rem .65rem; border-radius: .375rem; cursor: pointer; }
-button:hover { border-color: var(--accent); }
-select { border: 1px solid var(--btn-border); background: var(--surface); color: var(--fg); padding: .4rem; border-radius: .375rem; }
-input, select, textarea { font: inherit; }
-label { display: block; font-weight: 600; margin-bottom: .25rem; }
-.row { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: .75rem; }
-.card { border: 1px solid var(--border); padding: 1rem; border-radius: .75rem; background: var(--surface); box-shadow: 0 1px 0 rgba(0,0,0,.03); }
-header.header { margin-bottom: .75rem; }
-.toolbar { position: sticky; top: 0; z-index: 20; }
-.toolbar.topbar { border-radius: 0; border-left: 0; border-right: 0; }
-.layout { display: grid; gap: 1rem; align-items: start; }
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--fg);
+}
+
+a { color: var(--link); }
+
+a:hover { text-decoration: none; }
+
+header.header { margin-bottom: 0.75rem; }
+
+.toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--surface-translucent) 94%, transparent);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(12px);
+}
+
+.toolbar.topbar { border-radius: var(--radius-sm); }
+
+.layout {
+  display: grid;
+  gap: 1.25rem;
+  align-items: start;
+}
+
 @media (min-width: 1024px) {
   .layout { grid-template-columns: 2fr 1fr; }
 }
-.editor-col > * + * { margin-top: .75rem; }
-.preview-col { position: sticky; top: 76px; }
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  border: 1px solid var(--border);
+  padding: 1.25rem;
+  border-radius: var(--radius-lg);
+  background: var(--surface-panel);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(18px);
+}
+
+.editor-col > * + * { margin-top: 0.85rem; }
 .editor-root > * { min-width: 0; }
 
-/* Statblock accents */
-.statblock { border-left: 6px solid var(--accent); padding-left: 12px; }
+.preview-col { position: sticky; top: 84px; }
+
+.statblock {
+  border-left: 6px solid var(--accent);
+  padding-left: 12px;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-translucent) 94%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
 .statblock.enemy { --accent: var(--enemy-accent); }
 .statblock.environment { --accent: var(--env-accent); }
-.statblock h3 { color: var(--accent); }
+.statblock h3 {
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
 
 @media print {
-  .toolbar, .layout > :not(.print-only) { display: none !important; }
+  .toolbar,
+  .layout > :not(.print-only) {
+    display: none !important;
+  }
 }

--- a/apps/helianas-recipe-search/package.json
+++ b/apps/helianas-recipe-search/package.json
@@ -11,6 +11,7 @@
     "csv:from-json": "node scripts/json-to-csv.mjs"
   },
   "dependencies": {
+    "@my-monorepo/theme": "workspace:*",
     "minisearch": "^7.1.0",
     "vue": "^3.5.18"
   },

--- a/apps/helianas-recipe-search/src/style.css
+++ b/apps/helianas-recipe-search/src/style.css
@@ -1,9 +1,14 @@
-:root { color-scheme: light dark; }
+@import "@my-monorepo/theme/styles.css";
+
 html, body, #app { height: 100%; }
-body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
-button { border: 1px solid #ccc; background: #f6f6f6; }
-@media (prefers-color-scheme: dark) {
-  body { background: #111; color: #eee; }
-  button { background: #1f1f1f; color: #eee; border-color: #333; }
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--fg);
 }
 
+button {
+  font-family: inherit;
+}

--- a/apps/mapbox-pokemon-battler/package.json
+++ b/apps/mapbox-pokemon-battler/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@my-monorepo/theme": "workspace:*",
     "mapbox-gl": "^3.9.0",
     "vue": "^3.5.18",
     "vue-router": "^4.4.5"

--- a/apps/mapbox-pokemon-battler/src/components/hud/HudOverlay.vue
+++ b/apps/mapbox-pokemon-battler/src/components/hud/HudOverlay.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useStore } from '../../store'
+import { themeOptions } from '@my-monorepo/theme'
 import AppButton from '../ui/AppButton.vue'
 
 const emit = defineEmits(['open-team', 'recenter'])
@@ -8,7 +9,11 @@ const store = useStore()
 
 const caughtCount = computed(() => store.team.length)
 const active = computed(() => store.team[store.battle.partyIndex])
-const modeLabel = computed(() => (store.themeMode || 'auto').toUpperCase())
+const modeLabel = computed(() => {
+  if (store.themeMode === 'auto') return 'AUTO'
+  const meta = themeOptions.find((opt) => opt.value === store.themeMode)
+  return meta ? meta.label : store.themeMode.toUpperCase()
+})
 
 function setActive(i: number) {
   store.setPartyIndex(i)

--- a/apps/mapbox-pokemon-battler/src/style.css
+++ b/apps/mapbox-pokemon-battler/src/style.css
@@ -1,144 +1,168 @@
 @import "tailwindcss";
+@import "@my-monorepo/theme/styles.css";
 
-/* Theme variables */
 :root {
-  /* Motion + radius tokens */
-  --radius: 16px;
-  --radius-sm: 12px;
-  --blur: 10px;
-  --dur-fast: 140ms;
-  --dur: 220ms;
+  --radius: var(--radius-lg);
+  --radius-sm: var(--radius-sm);
+  --blur: 12px;
+  --dur-fast: var(--transition-fast);
+  --dur: var(--transition-base);
   --ease: cubic-bezier(0.2, 0.8, 0.2, 1);
   --ease-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
-  /* Pointer-driven parallax inputs */
-  --mx: 0; /* -1..1 */
-  --my: 0; /* -1..1 */
+  --mx: 0;
+  --my: 0;
   --liftY: 0px;
-  /* Pokemon Gold/Silver inspired day palette */
-  --bg: #f2efde;            /* warm parchment */
-  --text: #2a1f1a;          /* deep brown */
-  --panel: rgba(255, 252, 240, 0.75);
-  --panel-weak: rgba(255, 252, 240, 0.66);
-  --panel-border: #c8b794;
-  --button-bg: #fff8d8;
-  --button-text: #2a1f1a;
-  --accent: #ffb300;        /* brighter gold */
-  --success: #2ea043;       /* green */
-  --shadow: rgba(82, 62, 39, 0.25);
-  --overlay: rgba(42, 31, 26, 0.45);
+  --panel: color-mix(in srgb, var(--surface-panel) 95%, transparent);
+  --panel-weak: color-mix(in srgb, var(--surface-translucent) 85%, transparent);
+  --panel-border: var(--border);
+  --button-bg: var(--btn-bg);
+  --button-text: var(--btn-fg);
+  --accent: var(--accent);
+  --success: var(--env-accent);
+  --shadow: var(--shadow-soft);
+  --overlay: color-mix(in srgb, var(--overlay) 92%, transparent);
 }
 
-/* Prefer performance on small screens or reduced motion */
 @media (max-width: 640px) {
-  :root { --blur: 6px; }
+  :root { --blur: 8px; }
 }
+
 @media (prefers-reduced-motion: reduce) {
   :root { --blur: 4px; --dur-fast: 100ms; --dur: 160ms; }
 }
 
-.dark {
-  /* Pokemon Gold/Silver inspired night palette */
-  --bg: #0b1430;            /* deep navy */
-  --text: #dce7ff;          /* pale blue */
-  --panel: rgba(12, 22, 50, 0.66);
-  --panel-weak: rgba(12, 22, 50, 0.58);
-  --panel-border: #2a3d6b;
-  --button-bg: #0f1a3f;
-  --button-text: #e6efff;
-  --accent: #7cc4ff;        /* brighter crystal */
-  --success: #22c55e;
-  --shadow: rgba(0, 0, 0, 0.55);
-  --overlay: rgba(0, 0, 0, 0.55);
-}
-
-/* Base resets */
 * { box-sizing: border-box; }
 html, body, #app { margin: 0; height: 100%; }
+
 body {
-  color: var(--text);
+  color: var(--fg);
   background: var(--bg);
-  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji", sans-serif;
+  font-family: var(--font-sans);
 }
 
-/* Global utility classes (no @apply to avoid Tailwind v4 apply differences) */
 .fullscreen { position: absolute; inset: 0; }
+
 .panel {
   background: var(--panel);
-  border: 3px solid var(--panel-border);
+  border: 1px solid var(--panel-border);
   border-radius: var(--radius);
-  box-shadow: inset 0 2px 0 rgba(255,255,255,0.35), inset 0 -2px 0 rgba(0,0,0,0.08), 0 8px 18px var(--shadow);
-  padding: 0.9rem; /* a bit chunkier */
-  color: var(--text);
+  box-shadow: var(--shadow-card);
+  padding: 0.9rem;
+  color: var(--fg);
+  backdrop-filter: blur(var(--blur));
   transition: transform var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease);
 }
-.panel:hover { transform: translateY(-1px); box-shadow: inset 0 2px 0 rgba(255,255,255,0.35), inset 0 -2px 0 rgba(0,0,0,0.08), 0 12px 24px var(--shadow); }
+
+.panel:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-elevated);
+}
+
 .panel:active { transform: translateY(0); }
+
 .btn {
   appearance: none;
-  border: 3px solid var(--panel-border);
+  border: 1px solid var(--panel-border);
   background: var(--button-bg);
   color: var(--button-text);
   border-radius: var(--radius);
-  padding: 0.66rem 1rem; /* chunkier */
+  padding: 0.66rem 1rem;
   font-weight: 700;
   cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
   transition: background var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease);
-  box-shadow: inset 0 2px 0 rgba(255,255,255,0.3), inset 0 -2px 0 rgba(0,0,0,0.08), 0 2px 6px rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-button);
 }
-.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
-.btn.danger { background: #ef4444; border-color: #dc2626; color: #fff; }
-.btn:hover { filter: brightness(1.02); box-shadow: 0 6px 18px rgba(0,0,0,0.12); transform: translateY(-1px); }
-.btn:active { transform: translateY(0); box-shadow: inset 0 3px 8px rgba(0,0,0,0.22), inset 0 -2px 0 rgba(255,255,255,0.2), 0 2px 8px rgba(0,0,0,0.12); }
-.btn:focus-visible { outline: 2px solid color-mix(in oklab, var(--accent) 65%, white); outline-offset: 2px; }
+
+.btn.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
+}
+
+.btn.danger {
+  background: var(--enemy-accent);
+  border-color: var(--enemy-accent);
+  color: var(--bg);
+}
+
+.btn:hover {
+  box-shadow: var(--shadow-button-hover);
+  transform: translateY(-1px);
+  border-color: var(--accent);
+}
+
+.btn:active { transform: translateY(0); }
+
+.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
 .row { display: flex; gap: 0.5rem; align-items: center; }
 .stack { display: grid; gap: 0.5rem; }
-.overlay { position: absolute; inset: 0; background: var(--overlay); display: grid; place-items: center; }
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: var(--overlay);
+  display: grid;
+  place-items: center;
+}
+
 .overlay > .panel { animation: pop-in var(--dur) var(--ease-spring) both; }
-@keyframes pop-in { from { opacity: 0; transform: translateY(6px) scale(0.985); } to { opacity: 1; transform: translateY(0) scale(1); } }
 
-/* A11y utility */
-.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 1px, 1px); white-space: nowrap; border: 0; }
+@keyframes pop-in {
+  from { opacity: 0; transform: translateY(6px) scale(0.985); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
 
-/* Form controls */
-input, select, textarea {
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 1px, 1px);
+  white-space: nowrap;
+  border: 0;
+}
+
+input,
+select,
+textarea {
   background: var(--button-bg);
   color: var(--button-text);
   border: 1px solid var(--panel-border);
   border-radius: var(--radius-sm);
   transition: border-color var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease);
 }
-input:focus-visible, select:focus-visible, textarea:focus-visible {
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
   outline: none;
-  border-color: color-mix(in oklab, var(--accent) 65%, white);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent) 20%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 65%, white);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
-/* Mapbox control theming */
-.mapboxgl-ctrl, .mapboxgl-ctrl-group { background: var(--panel); border: 3px solid var(--panel-border); border-radius: var(--radius-sm); box-shadow: 0 6px 16px var(--shadow); }
-.mapboxgl-ctrl button { background: var(--button-bg); color: var(--button-text); transition: background var(--dur-fast) var(--ease); }
-.mapboxgl-ctrl button:hover { background: var(--panel-weak); }
+.mapboxgl-ctrl,
+.mapboxgl-ctrl-group {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(var(--blur));
+}
 
-/* Move type colorways */
-.type-normal   { background: #9ca3af; border: 1px solid #6b7280; color: #ffffff; box-shadow: 0 2px 8px rgba(0,0,0,0.12); }
-.type-fire     { background: #f97316; border: 1px solid #ea580c; color: #ffffff; }
-.type-water    { background: #3b82f6; border: 1px solid #2563eb; color: #ffffff; }
-.type-grass    { background: #22c55e; border: 1px solid #16a34a; color: #052e16; }
-.type-electric { background: #eab308; border: 1px solid #ca8a04; color: #111827; }
-.type-ice      { background: #06b6d4; border: 1px solid #0891b2; color: #0f172a; }
-.type-fighting { background: #dc2626; border: 1px solid #b91c1c; color: #ffffff; }
-.type-poison   { background: #7c3aed; border: 1px solid #6d28d9; color: #f5f3ff; }
-.type-ground   { background: #d4a373; border: 1px solid #b58863; color: #1f2937; }
-.type-flying   { background: #38bdf8; border: 1px solid #0ea5e9; color: #0c4a6e; }
-.type-psychic  { background: #ec4899; border: 1px solid #db2777; color: #ffffff; }
-.type-bug      { background: #84cc16; border: 1px solid #65a30d; color: #052e16; }
-.type-rock     { background: #b45309; border: 1px solid #92400e; color: #ffffff; }
-.type-ghost    { background: #7c3aed; border: 1px solid #6d28d9; color: #f5f3ff; }
-.type-dragon   { background: #8b5cf6; border: 1px solid #7c3aed; color: #f5f3ff; }
-.type-dark     { background: #374151; border: 1px solid #1f2937; color: #e5e7eb; }
-.type-steel    { background: #cbd5e1; border: 1px solid #64748b; color: #0f172a; }
-.type-fairy    { background: #f472b6; border: 1px solid #ec4899; color: #701a75; }
+.mapboxgl-ctrl button {
+  background: var(--button-bg);
+  color: var(--button-text);
+  transition: background var(--dur-fast) var(--ease);
+}
 
-/* Router view page transitions */
-.view-enter-active, .view-leave-active { transition: opacity var(--dur) var(--ease), transform var(--dur) var(--ease); }
-.view-enter-from { opacity: 0; transform: translateY(6px) scale(0.99); }
-.view-leave-to   { opacity: 0; transform: translateY(-6px) scale(0.99); }
+.mapboxgl-ctrl button:hover {
+  background: var(--panel-weak);
+}

--- a/apps/mapbox-weather-vis/package.json
+++ b/apps/mapbox-weather-vis/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@my-monorepo/theme": "workspace:*",
     "mapbox-gl": "^3.9.0",
     "three": "^0.165.0",
     "vue": "^3.5.18"

--- a/apps/mapbox-weather-vis/src/style.css
+++ b/apps/mapbox-weather-vis/src/style.css
@@ -1,30 +1,12 @@
-:root {
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-  color: #0f172a;
-  background-color: #f8fafc;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
+@import "@my-monorepo/theme/styles.css";
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
-
-html,
-body {
-  height: 100%;
-}
+html, body { height: 100%; }
 
 body {
   margin: 0;
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--fg);
 }
 
-#app {
-  height: 100%;
-}
+#app { height: 100%; }

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -1,0 +1,14 @@
+# @my-monorepo/design-tokens
+
+Shared design foundations for the apps in this monorepo. The package is intentionally
+framework-agnostic and exposes the color palettes, typography scales, radii, shadows and
+theme metadata that power the rest of the design system. Tokens are plain TypeScript
+objects so they can be consumed from UI libraries, build tooling or even server-side
+renderers without needing a CSS pipeline.
+
+```ts
+import { fonts, radii, themeVariables, themeMeta } from '@my-monorepo/design-tokens'
+```
+
+Use these exports when you need to align bespoke components with the core theme, or when
+you want to generate documentation / theming controls.

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@my-monorepo/ui",
+  "name": "@my-monorepo/design-tokens",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -10,11 +10,5 @@
       "import": "./src/index.ts"
     },
     "./*": "./src/*"
-  },
-  "peerDependencies": {
-    "vue": "^3.5.0"
-  },
-  "dependencies": {
-    "@my-monorepo/design-tokens": "workspace:*"
   }
 }

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,0 +1,147 @@
+export const fonts = {
+  sans: "'Space Grotesk', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif",
+  mono: "'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Source Code Pro', monospace",
+  wide: "'Space Grotesk', 'Orbitron', 'Inter', sans-serif"
+} as const
+
+export const radii = {
+  xs: '0.35rem',
+  sm: '0.65rem',
+  md: '0.9rem',
+  lg: '1.25rem',
+  xl: '1.75rem',
+  pill: '999px'
+} as const
+
+export const transitions = {
+  fast: '140ms cubic-bezier(0.2, 0.8, 0.2, 1)',
+  base: '220ms cubic-bezier(0.2, 0.8, 0.2, 1)',
+  spring: '260ms cubic-bezier(0.16, 0.84, 0.44, 1)'
+} as const
+
+export const shadows = {
+  button: '0 12px 30px -22px rgba(34, 211, 238, 0.8), inset 0 0 0 1px rgba(255,255,255,0.04)',
+  buttonHover: '0 18px 40px -22px rgba(244, 114, 208, 0.75), inset 0 0 0 1px rgba(255,255,255,0.06)',
+  card: '0 30px 80px -50px rgba(16, 20, 60, 0.95), 0 0 0 1px rgba(34, 211, 238, 0.18)',
+  elevated: '0 24px 70px -35px rgba(12, 13, 40, 0.95), 0 0 0 1px rgba(56, 189, 248, 0.25)',
+  glow: '0 0 0 1px rgba(244, 114, 208, 0.4), 0 0 35px rgba(244, 114, 208, 0.22)'
+} as const
+
+const cyberpunkVars = {
+  '--cp-color-bg': '#05060a',
+  '--cp-color-surface': '#0f1325',
+  '--cp-color-surface-2': '#171c38',
+  '--cp-color-border-soft': 'rgba(56, 189, 248, 0.24)',
+  '--cp-color-border-strong': 'rgba(244, 114, 208, 0.45)',
+  '--cp-color-border-muted': 'rgba(148, 163, 184, 0.2)',
+  '--cp-color-text': '#ecf2ff',
+  '--cp-color-text-muted': '#94a3b8',
+  '--cp-color-accent': '#f472d0',
+  '--cp-color-accent-weak': 'rgba(244, 114, 208, 0.16)',
+  '--cp-color-accent-strong': '#22d3ee',
+  '--cp-color-positive': '#4ade80',
+  '--cp-color-warning': '#facc15',
+  '--cp-color-danger': '#fb7185',
+  '--cp-color-link': '#38bdf8',
+  '--cp-button-bg': 'rgba(15, 23, 42, 0.72)',
+  '--cp-button-fg': '#f8fafc',
+  '--cp-button-border': 'rgba(148, 163, 184, 0.32)',
+  '--cp-button-border-strong': 'rgba(244, 114, 208, 0.45)',
+  '--cp-surface-translucent': 'color-mix(in srgb, #0f1325 92%, transparent)',
+  '--cp-surface-veil': 'color-mix(in srgb, #171c38 78%, transparent)',
+  '--cp-surface-panel': 'color-mix(in srgb, #171c38 65%, transparent)',
+  '--cp-overlay': 'rgba(5, 6, 10, 0.55)',
+  '--cp-gradient-bg': 'radial-gradient(120% 120% at 0% 0%, rgba(244, 114, 208, 0.14) 0%, transparent 58%), radial-gradient(120% 120% at 100% 0%, rgba(34, 211, 238, 0.12) 0%, transparent 60%), radial-gradient(180% 150% at 50% 100%, rgba(15, 23, 42, 0.85) 0%, rgba(5, 6, 10, 0.95) 100%)'
+} as const
+
+const neonNoirVars = {
+  '--cp-color-bg': '#04050f',
+  '--cp-color-surface': '#0e1324',
+  '--cp-color-surface-2': '#161b33',
+  '--cp-color-border-soft': 'rgba(96, 165, 250, 0.28)',
+  '--cp-color-border-strong': 'rgba(56, 189, 248, 0.48)',
+  '--cp-color-border-muted': 'rgba(79, 70, 229, 0.2)',
+  '--cp-color-text': '#dfe7ff',
+  '--cp-color-text-muted': '#9ca3c7',
+  '--cp-color-accent': '#818cf8',
+  '--cp-color-accent-weak': 'rgba(129, 140, 248, 0.18)',
+  '--cp-color-accent-strong': '#38bdf8',
+  '--cp-color-positive': '#34d399',
+  '--cp-color-warning': '#fbbf24',
+  '--cp-color-danger': '#f87171',
+  '--cp-color-link': '#60a5fa',
+  '--cp-button-bg': 'rgba(12, 19, 44, 0.78)',
+  '--cp-button-fg': '#f5f7ff',
+  '--cp-button-border': 'rgba(129, 140, 248, 0.32)',
+  '--cp-button-border-strong': 'rgba(56, 189, 248, 0.45)',
+  '--cp-surface-translucent': 'color-mix(in srgb, #0e1324 90%, transparent)',
+  '--cp-surface-veil': 'color-mix(in srgb, #161b33 74%, transparent)',
+  '--cp-surface-panel': 'color-mix(in srgb, #161b33 62%, transparent)',
+  '--cp-overlay': 'rgba(4, 7, 17, 0.6)',
+  '--cp-gradient-bg': 'radial-gradient(140% 120% at 0% 0%, rgba(129, 140, 248, 0.16) 0%, transparent 55%), radial-gradient(120% 120% at 100% 0%, rgba(56, 189, 248, 0.12) 0%, transparent 60%), radial-gradient(160% 140% at 50% 100%, rgba(8, 11, 26, 0.9) 0%, rgba(4, 5, 15, 0.96) 100%)'
+} as const
+
+const synthwaveDawnVars = {
+  '--cp-color-bg': '#14040f',
+  '--cp-color-surface': '#1d0821',
+  '--cp-color-surface-2': '#2a1033',
+  '--cp-color-border-soft': 'rgba(249, 115, 22, 0.28)',
+  '--cp-color-border-strong': 'rgba(236, 72, 153, 0.45)',
+  '--cp-color-border-muted': 'rgba(253, 186, 116, 0.2)',
+  '--cp-color-text': '#ffeefc',
+  '--cp-color-text-muted': '#f9a8d4',
+  '--cp-color-accent': '#ec4899',
+  '--cp-color-accent-weak': 'rgba(236, 72, 153, 0.2)',
+  '--cp-color-accent-strong': '#facc15',
+  '--cp-color-positive': '#4ade80',
+  '--cp-color-warning': '#fbbf24',
+  '--cp-color-danger': '#fb7185',
+  '--cp-color-link': '#f472b6',
+  '--cp-button-bg': 'rgba(45, 14, 62, 0.78)',
+  '--cp-button-fg': '#fff5fb',
+  '--cp-button-border': 'rgba(236, 72, 153, 0.35)',
+  '--cp-button-border-strong': 'rgba(250, 204, 21, 0.4)',
+  '--cp-surface-translucent': 'color-mix(in srgb, #1d0821 92%, transparent)',
+  '--cp-surface-veil': 'color-mix(in srgb, #2a1033 74%, transparent)',
+  '--cp-surface-panel': 'color-mix(in srgb, #2a1033 64%, transparent)',
+  '--cp-overlay': 'rgba(17, 6, 24, 0.62)',
+  '--cp-gradient-bg': 'radial-gradient(130% 140% at 0% 0%, rgba(236, 72, 153, 0.18) 0%, transparent 60%), radial-gradient(140% 120% at 100% 0%, rgba(250, 204, 21, 0.12) 0%, transparent 60%), radial-gradient(160% 150% at 50% 100%, rgba(30, 8, 45, 0.92) 0%, rgba(14, 4, 19, 0.96) 100%)'
+} as const
+
+export const themeVariables = {
+  'cyberpunk': cyberpunkVars,
+  'neon-noir': neonNoirVars,
+  'synthwave-dawn': synthwaveDawnVars
+} as const
+
+export type ThemeName = keyof typeof themeVariables
+export type ThemeVariables = typeof themeVariables[ThemeName]
+export type ThemeVariableName = keyof ThemeVariables
+
+export const themeOrder: ThemeName[] = ['cyberpunk', 'neon-noir', 'synthwave-dawn']
+
+export const defaultThemeName: ThemeName = 'cyberpunk'
+
+export const themeMeta: Record<ThemeName, { label: string; description: string; accent: string }> = {
+  'cyberpunk': {
+    label: 'Cyberpunk Pulse',
+    description: 'Electric magenta and cyan pulses with deep midnight surfaces.',
+    accent: '#f472d0'
+  },
+  'neon-noir': {
+    label: 'Neon Noir',
+    description: 'Moody indigo base with luminous periwinkle and cyan edges.',
+    accent: '#818cf8'
+  },
+  'synthwave-dawn': {
+    label: 'Synthwave Dawn',
+    description: 'Sunrise magentas and amber glows inspired by 80s album art.',
+    accent: '#ec4899'
+  }
+}
+
+export function isThemeName(value: string): value is ThemeName {
+  return themeOrder.includes(value as ThemeName)
+}
+
+export const themeVariablesList: ThemeVariableName[] = Object.keys(cyberpunkVars) as ThemeVariableName[]

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -1,0 +1,13 @@
+# @my-monorepo/theme
+
+Global theme helpers and CSS surface for the monorepo. Import the CSS once per app to get
+the neon cyberpunk baseline, then use the helper utilities to switch between presets or to
+persist a user preference.
+
+```ts
+import { applyTheme, themeOptions } from '@my-monorepo/theme'
+import '@my-monorepo/theme/styles.css'
+```
+
+`applyTheme('neon-noir', { persist: true })` will update the `<html>` tag, set CSS custom
+properties and remember the choice across sessions.

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@my-monorepo/ui",
+  "name": "@my-monorepo/theme",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -9,10 +9,8 @@
     ".": {
       "import": "./src/index.ts"
     },
+    "./styles.css": "./src/index.css",
     "./*": "./src/*"
-  },
-  "peerDependencies": {
-    "vue": "^3.5.0"
   },
   "dependencies": {
     "@my-monorepo/design-tokens": "workspace:*"

--- a/packages/theme/src/index.css
+++ b/packages/theme/src/index.css
@@ -1,0 +1,280 @@
+:root,
+:root[data-theme='cyberpunk'] {
+  color-scheme: dark;
+  font-family: var(--font-sans);
+  --font-sans: 'Space Grotesk', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Source Code Pro', monospace;
+  --font-wide: 'Space Grotesk', 'Orbitron', 'Inter', sans-serif;
+
+  --radius-xs: 0.35rem;
+  --radius-sm: 0.65rem;
+  --radius-md: 0.9rem;
+  --radius-lg: 1.25rem;
+  --radius-xl: 1.75rem;
+  --radius-pill: 999px;
+
+  --shadow-button: 0 12px 30px -22px rgba(34, 211, 238, 0.8), inset 0 0 0 1px rgba(255,255,255,0.04);
+  --shadow-button-hover: 0 18px 40px -22px rgba(244, 114, 208, 0.75), inset 0 0 0 1px rgba(255,255,255,0.06);
+  --shadow-card: 0 30px 80px -50px rgba(16, 20, 60, 0.95), 0 0 0 1px rgba(34, 211, 238, 0.18);
+  --shadow-elevated: 0 24px 70px -35px rgba(12, 13, 40, 0.95), 0 0 0 1px rgba(56, 189, 248, 0.25);
+  --shadow-soft: 0 18px 60px -40px rgba(34, 211, 238, 0.5);
+  --shadow-glow: 0 0 0 1px rgba(244, 114, 208, 0.4), 0 0 35px rgba(244, 114, 208, 0.22);
+
+  --transition-fast: 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  --transition-base: 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  --transition-spring: 260ms cubic-bezier(0.16, 0.84, 0.44, 1);
+
+  --cp-color-bg: #05060a;
+  --cp-color-surface: #0f1325;
+  --cp-color-surface-2: #171c38;
+  --cp-color-border-soft: rgba(56, 189, 248, 0.24);
+  --cp-color-border-strong: rgba(244, 114, 208, 0.45);
+  --cp-color-border-muted: rgba(148, 163, 184, 0.2);
+  --cp-color-text: #ecf2ff;
+  --cp-color-text-muted: #94a3b8;
+  --cp-color-accent: #f472d0;
+  --cp-color-accent-weak: rgba(244, 114, 208, 0.16);
+  --cp-color-accent-strong: #22d3ee;
+  --cp-color-positive: #4ade80;
+  --cp-color-warning: #facc15;
+  --cp-color-danger: #fb7185;
+  --cp-color-link: #38bdf8;
+  --cp-button-bg: rgba(15, 23, 42, 0.72);
+  --cp-button-fg: #f8fafc;
+  --cp-button-border: rgba(148, 163, 184, 0.32);
+  --cp-button-border-strong: rgba(244, 114, 208, 0.45);
+  --cp-surface-translucent: color-mix(in srgb, #0f1325 92%, transparent);
+  --cp-surface-veil: color-mix(in srgb, #171c38 78%, transparent);
+  --cp-surface-panel: color-mix(in srgb, #171c38 65%, transparent);
+  --cp-overlay: rgba(5, 6, 10, 0.55);
+  --cp-gradient-bg: radial-gradient(120% 120% at 0% 0%, rgba(244, 114, 208, 0.14) 0%, transparent 58%), radial-gradient(120% 120% at 100% 0%, rgba(34, 211, 238, 0.12) 0%, transparent 60%), radial-gradient(180% 150% at 50% 100%, rgba(15, 23, 42, 0.85) 0%, rgba(5, 6, 10, 0.95) 100%);
+
+  --bg: var(--cp-color-bg);
+  --fg: var(--cp-color-text);
+  --muted: var(--cp-color-text-muted);
+  --surface: var(--cp-color-surface);
+  --surface-2: var(--cp-color-surface-2);
+  --surface-translucent: var(--cp-surface-translucent);
+  --surface-veil: var(--cp-surface-veil);
+  --surface-panel: var(--cp-surface-panel);
+  --border: var(--cp-color-border-soft);
+  --border-soft: var(--cp-color-border-soft);
+  --border-strong: var(--cp-color-border-strong);
+  --border-muted: var(--cp-color-border-muted);
+  --accent: var(--cp-color-accent);
+  --accent-weak: var(--cp-color-accent-weak);
+  --accent-strong: var(--cp-color-accent-strong);
+  --enemy-accent: var(--cp-color-danger);
+  --env-accent: var(--cp-color-positive);
+  --danger-soft: color-mix(in srgb, var(--enemy-accent) 16%, transparent);
+  --success-soft: color-mix(in srgb, var(--env-accent) 18%, transparent);
+  --danger-border: color-mix(in srgb, var(--enemy-accent) 45%, transparent);
+  --success-border: color-mix(in srgb, var(--env-accent) 45%, transparent);
+  --btn-bg: var(--cp-button-bg);
+  --btn-fg: var(--cp-button-fg);
+  --btn-border: var(--cp-button-border);
+  --btn-border-strong: var(--cp-button-border-strong);
+  --link: var(--cp-color-link);
+  --overlay: var(--cp-overlay);
+  --gridline: rgba(148, 163, 184, 0.08);
+}
+
+[data-theme='neon-noir'] {
+  --cp-color-bg: #04050f;
+  --cp-color-surface: #0e1324;
+  --cp-color-surface-2: #161b33;
+  --cp-color-border-soft: rgba(96, 165, 250, 0.28);
+  --cp-color-border-strong: rgba(56, 189, 248, 0.48);
+  --cp-color-border-muted: rgba(79, 70, 229, 0.2);
+  --cp-color-text: #dfe7ff;
+  --cp-color-text-muted: #9ca3c7;
+  --cp-color-accent: #818cf8;
+  --cp-color-accent-weak: rgba(129, 140, 248, 0.18);
+  --cp-color-accent-strong: #38bdf8;
+  --cp-color-positive: #34d399;
+  --cp-color-warning: #fbbf24;
+  --cp-color-danger: #f87171;
+  --cp-color-link: #60a5fa;
+  --cp-button-bg: rgba(12, 19, 44, 0.78);
+  --cp-button-fg: #f5f7ff;
+  --cp-button-border: rgba(129, 140, 248, 0.32);
+  --cp-button-border-strong: rgba(56, 189, 248, 0.45);
+  --cp-surface-translucent: color-mix(in srgb, #0e1324 90%, transparent);
+  --cp-surface-veil: color-mix(in srgb, #161b33 74%, transparent);
+  --cp-surface-panel: color-mix(in srgb, #161b33 62%, transparent);
+  --cp-overlay: rgba(4, 7, 17, 0.6);
+  --cp-gradient-bg: radial-gradient(140% 120% at 0% 0%, rgba(129, 140, 248, 0.16) 0%, transparent 55%), radial-gradient(120% 120% at 100% 0%, rgba(56, 189, 248, 0.12) 0%, transparent 60%), radial-gradient(160% 140% at 50% 100%, rgba(8, 11, 26, 0.9) 0%, rgba(4, 5, 15, 0.96) 100%);
+}
+
+[data-theme='synthwave-dawn'] {
+  --cp-color-bg: #14040f;
+  --cp-color-surface: #1d0821;
+  --cp-color-surface-2: #2a1033;
+  --cp-color-border-soft: rgba(249, 115, 22, 0.28);
+  --cp-color-border-strong: rgba(236, 72, 153, 0.45);
+  --cp-color-border-muted: rgba(253, 186, 116, 0.2);
+  --cp-color-text: #ffeefc;
+  --cp-color-text-muted: #f9a8d4;
+  --cp-color-accent: #ec4899;
+  --cp-color-accent-weak: rgba(236, 72, 153, 0.2);
+  --cp-color-accent-strong: #facc15;
+  --cp-color-positive: #4ade80;
+  --cp-color-warning: #fbbf24;
+  --cp-color-danger: #fb7185;
+  --cp-color-link: #f472b6;
+  --cp-button-bg: rgba(45, 14, 62, 0.78);
+  --cp-button-fg: #fff5fb;
+  --cp-button-border: rgba(236, 72, 153, 0.35);
+  --cp-button-border-strong: rgba(250, 204, 21, 0.4);
+  --cp-surface-translucent: color-mix(in srgb, #1d0821 92%, transparent);
+  --cp-surface-veil: color-mix(in srgb, #2a1033 74%, transparent);
+  --cp-surface-panel: color-mix(in srgb, #2a1033 64%, transparent);
+  --cp-overlay: rgba(17, 6, 24, 0.62);
+  --cp-gradient-bg: radial-gradient(130% 140% at 0% 0%, rgba(236, 72, 153, 0.18) 0%, transparent 60%), radial-gradient(140% 120% at 100% 0%, rgba(250, 204, 21, 0.12) 0%, transparent 60%), radial-gradient(160% 150% at 50% 100%, rgba(30, 8, 45, 0.92) 0%, rgba(14, 4, 19, 0.96) 100%);
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --cp-color-bg: #14040f;
+    --cp-color-surface: #1d0821;
+    --cp-color-surface-2: #2a1033;
+    --cp-color-border-soft: rgba(249, 115, 22, 0.28);
+    --cp-color-border-strong: rgba(236, 72, 153, 0.45);
+    --cp-color-border-muted: rgba(253, 186, 116, 0.2);
+    --cp-color-text: #ffeefc;
+    --cp-color-text-muted: #f9a8d4;
+    --cp-color-accent: #ec4899;
+    --cp-color-accent-weak: rgba(236, 72, 153, 0.2);
+    --cp-color-accent-strong: #facc15;
+    --cp-color-positive: #4ade80;
+    --cp-color-warning: #fbbf24;
+    --cp-color-danger: #fb7185;
+    --cp-color-link: #f472b6;
+    --cp-button-bg: rgba(45, 14, 62, 0.78);
+    --cp-button-fg: #fff5fb;
+    --cp-button-border: rgba(236, 72, 153, 0.35);
+    --cp-button-border-strong: rgba(250, 204, 21, 0.4);
+    --cp-surface-translucent: color-mix(in srgb, #1d0821 92%, transparent);
+    --cp-surface-veil: color-mix(in srgb, #2a1033 74%, transparent);
+    --cp-surface-panel: color-mix(in srgb, #2a1033 64%, transparent);
+    --cp-overlay: rgba(17, 6, 24, 0.62);
+    --cp-gradient-bg: radial-gradient(130% 140% at 0% 0%, rgba(236, 72, 153, 0.18) 0%, transparent 60%), radial-gradient(140% 120% at 100% 0%, rgba(250, 204, 21, 0.12) 0%, transparent 60%), radial-gradient(160% 150% at 50% 100%, rgba(30, 8, 45, 0.92) 0%, rgba(14, 4, 19, 0.96) 100%);
+  }
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  color: var(--fg);
+  background-color: var(--bg);
+  background-image: var(--cp-gradient-bg);
+  background-attachment: fixed;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.6;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  position: relative;
+  min-height: 100%;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(90deg, transparent 0, rgba(56, 189, 248, 0.12) 1px, transparent 2px),
+    linear-gradient(0deg, transparent 0, rgba(244, 114, 208, 0.1) 1px, transparent 2px);
+  background-size: 120px 120px;
+  opacity: 0.14;
+  mix-blend-mode: screen;
+  z-index: -1;
+}
+
+a {
+  color: var(--link);
+  text-decoration: none;
+  transition: color var(--transition-fast), text-shadow var(--transition-fast);
+}
+
+a:hover {
+  text-shadow: 0 0 12px color-mix(in srgb, var(--link) 60%, transparent);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: var(--fg);
+  background: var(--surface-translucent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 0.85rem;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
+  box-shadow: none;
+}
+
+button {
+  cursor: pointer;
+  background: var(--btn-bg);
+  color: var(--btn-fg);
+  border: 1px solid var(--btn-border);
+  box-shadow: var(--shadow-button);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.72rem;
+}
+
+button:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-button-hover);
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+fieldset {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+}
+
+code,
+pre {
+  font-family: var(--font-mono);
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+  padding: 0.2rem 0.4rem;
+  border-radius: var(--radius-xs);
+}
+
+::selection {
+  background: color-mix(in srgb, var(--accent) 40%, transparent);
+  color: var(--bg);
+}
+
+.glass-panel {
+  background: var(--surface-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(14px);
+}
+
+.surface-outline {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface-translucent);
+}

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,0 +1,144 @@
+import {
+  defaultThemeName,
+  fonts,
+  radii,
+  shadows,
+  themeMeta,
+  themeOrder,
+  themeVariables,
+  themeVariablesList,
+  transitions,
+  type ThemeName,
+  type ThemeVariableName,
+  type ThemeVariables
+} from '@my-monorepo/design-tokens'
+
+export type ThemePreference = ThemeName | 'system'
+
+export const THEME_STORAGE_KEY = 'my-monorepo:theme'
+
+const themeVariableNames: ThemeVariableName[] = [...themeVariablesList]
+
+export interface ApplyThemeOptions {
+  root?: HTMLElement | null
+  persist?: boolean
+  storageKey?: string
+}
+
+function getDocumentElement(root?: HTMLElement | null): HTMLElement | null {
+  if (root) return root
+  if (typeof document !== 'undefined' && document?.documentElement) {
+    return document.documentElement as HTMLElement
+  }
+  return null
+}
+
+function setInlineThemeVariables(root: HTMLElement, theme: ThemeName | null) {
+  for (const name of themeVariableNames) {
+    if (theme) {
+      root.style.setProperty(name as string, themeVariables[theme][name])
+    } else {
+      root.style.removeProperty(name as string)
+    }
+  }
+}
+
+export function isThemePreference(value: string | null | undefined): value is ThemePreference {
+  if (!value) return false
+  if (value === 'system') return true
+  return themeOrder.includes(value as ThemeName)
+}
+
+export function applyTheme(theme: ThemePreference, options: ApplyThemeOptions = {}) {
+  const root = getDocumentElement(options.root)
+  if (!root) return theme
+
+  if (theme === 'system') {
+    root.removeAttribute('data-theme')
+    setInlineThemeVariables(root, null)
+  } else {
+    root.setAttribute('data-theme', theme)
+    setInlineThemeVariables(root, theme)
+  }
+
+  if (options.persist) {
+    storeThemePreference(theme, options.storageKey)
+  }
+
+  return theme
+}
+
+export interface StoreThemeOptions {
+  storageKey?: string
+}
+
+export function storeThemePreference(theme: ThemePreference, storageKey?: string) {
+  try {
+    if (typeof window === 'undefined' || !window?.localStorage) return
+    window.localStorage.setItem(storageKey ?? THEME_STORAGE_KEY, theme)
+  } catch {}
+}
+
+export function clearThemePreference(storageKey?: string) {
+  try {
+    if (typeof window === 'undefined' || !window?.localStorage) return
+    window.localStorage.removeItem(storageKey ?? THEME_STORAGE_KEY)
+  } catch {}
+}
+
+export function readStoredTheme(storageKey?: string): ThemePreference | null {
+  try {
+    if (typeof window === 'undefined' || !window?.localStorage) return null
+    const raw = window.localStorage.getItem(storageKey ?? THEME_STORAGE_KEY)
+    return isThemePreference(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
+
+export interface InitThemeOptions {
+  root?: HTMLElement | null
+  storageKey?: string
+  fallback?: ThemePreference
+  persistComputed?: boolean
+}
+
+export function initTheme(options: InitThemeOptions = {}) {
+  const stored = readStoredTheme(options.storageKey)
+  if (stored) {
+    applyTheme(stored, { root: options.root, storageKey: options.storageKey })
+    return stored
+  }
+
+  const fallback = options.fallback ?? defaultThemeName
+  if (fallback !== 'system') {
+    applyTheme(fallback, {
+      root: options.root,
+      storageKey: options.storageKey,
+      persist: options.persistComputed ?? false
+    })
+  }
+  return fallback
+}
+
+export const themeOptions = themeOrder.map((value) => ({
+  value,
+  label: themeMeta[value].label,
+  description: themeMeta[value].description,
+  accent: themeMeta[value].accent
+})) as ReadonlyArray<{ value: ThemeName; label: string; description: string; accent: string }>
+
+export {
+  defaultThemeName,
+  fonts,
+  radii,
+  shadows,
+  themeMeta,
+  themeOrder,
+  themeVariables,
+  themeVariablesList,
+  transitions,
+  type ThemeName,
+  type ThemeVariableName,
+  type ThemeVariables
+}

--- a/packages/theme/tsconfig.json
+++ b/packages/theme/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../design-tokens" }
+  ]
+}

--- a/packages/ui/src/components/AppBadge.vue
+++ b/packages/ui/src/components/AppBadge.vue
@@ -4,16 +4,16 @@ const props = withDefaults(defineProps<{
 }>(), { variant: 'neutral' })
 
 const map: Record<string, string> = {
-  default: 'bg-[var(--surface-2)] text-[var(--fg)] border-[var(--border)]',
-  accent: 'bg-[var(--accent-weak)] text-[var(--fg)] border-[var(--accent)]',
-  neutral: 'bg-[var(--surface-2)] text-[var(--muted)] border-[var(--border)]',
-  danger: 'bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-200 dark:border-red-700',
-  success: 'bg-emerald-100 text-emerald-700 border-emerald-300 dark:bg-emerald-900/30 dark:text-emerald-200 dark:border-emerald-700',
+  default: 'bg-[color:var(--surface-veil)] text-[color:var(--fg)] border-[color:var(--border)]',
+  accent: 'bg-[color:var(--accent-weak)] text-[color:var(--accent)] border-[color:var(--accent)]',
+  neutral: 'bg-[color:var(--surface-translucent)] text-[color:var(--muted)] border-[color:var(--border-muted)]',
+  danger: 'bg-[color:var(--danger-soft)] text-[color:var(--enemy-accent)] border-[color:var(--danger-border)]',
+  success: 'bg-[color:var(--success-soft)] text-[color:var(--env-accent)] border-[color:var(--success-border)]',
 }
 </script>
 
 <template>
-  <span :class="['inline-flex items-center rounded border px-2 py-0.5 text-xs', map[props.variant]]">
+  <span :class="['inline-flex items-center gap-1 rounded-[var(--radius-pill)] border px-3 py-1 text-[0.62rem] font-semibold uppercase tracking-[0.24em]', map[props.variant]]">
     <slot />
   </span>
 </template>

--- a/packages/ui/src/components/AppButton.vue
+++ b/packages/ui/src/components/AppButton.vue
@@ -7,21 +7,21 @@ const props = withDefaults(defineProps<{
   disabled?: boolean
 }>(), { variant: 'default', size: 'md', block: false, loading: false, disabled: false })
 
-const base = 'inline-flex items-center justify-center rounded-md border transition-colors select-none'
+const base = 'inline-flex items-center justify-center gap-2 rounded-[var(--radius-sm)] border border-[color:var(--btn-border)] bg-[color:var(--btn-bg)] px-3 py-2 text-[0.72rem] font-semibold uppercase tracking-[0.16em] text-[color:var(--btn-fg)] transition-all duration-200 select-none shadow-[var(--shadow-button)] hover:border-[color:var(--accent)] hover:shadow-[var(--shadow-button-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-[color:var(--surface)] active:translate-y-[1px]'
 const sizes: Record<string, string> = {
-  xs: 'px-2 py-1 text-xs',
-  sm: 'px-2.5 py-1.5 text-sm',
-  md: 'px-3 py-2 text-sm',
-  lg: 'px-4 py-2.5 text-base',
+  xs: 'px-2.5 py-1 text-[0.62rem]',
+  sm: 'px-3 py-1.5 text-[0.68rem]',
+  md: 'px-4 py-2 text-[0.75rem]',
+  lg: 'px-5 py-2.5 text-[0.82rem]',
 }
 const variants: Record<string, string> = {
-  default: 'bg-[var(--btn-bg)] text-[var(--btn-fg)] border-[var(--btn-border)] hover:border-[var(--accent)]',
-  primary: 'bg-[color:var(--accent)] text-white border-[color:var(--accent)] hover:opacity-90',
-  secondary: 'bg-[var(--surface-2)] text-[var(--fg)] border-[var(--border)] hover:border-[var(--accent)]',
-  danger: 'bg-red-600 text-white border-red-600 hover:opacity-90',
-  ghost: 'bg-transparent text-[var(--fg)] border-transparent hover:border-[var(--border)]',
-  outline: 'bg-transparent text-[var(--fg)] border-[var(--btn-border)] hover:border-[var(--accent)]',
-  subtle: 'bg-transparent text-[var(--muted)] border-transparent hover:text-[var(--fg)]',
+  default: '',
+  primary: 'bg-[color:var(--accent)] text-[color:var(--bg)] border-[color:var(--accent)] shadow-[var(--shadow-button-hover)] hover:shadow-[var(--shadow-button-hover)] focus-visible:ring-[color:var(--accent-strong)]',
+  secondary: 'bg-[color:var(--surface-veil)] text-[color:var(--fg)] border-[color:var(--border)]',
+  danger: 'bg-[#fb7185] text-white border-[#fb7185] shadow-[var(--shadow-button-hover)] focus-visible:ring-[rgba(251,113,133,0.5)]',
+  ghost: 'bg-transparent text-[color:var(--fg)] border-transparent shadow-none hover:border-[color:var(--border)] hover:bg-[color:var(--surface-translucent)] hover:shadow-none focus-visible:ring-[color:var(--accent-weak)]',
+  outline: 'bg-transparent text-[color:var(--fg)] border-[color:var(--border)] shadow-none hover:border-[color:var(--accent)] hover:shadow-none',
+  subtle: 'bg-transparent text-[color:var(--muted)] border-transparent shadow-none hover:text-[color:var(--fg)] hover:border-[color:var(--border)] hover:shadow-none',
 }
 </script>
 

--- a/packages/ui/src/components/AppButtonGroup.vue
+++ b/packages/ui/src/components/AppButtonGroup.vue
@@ -8,15 +8,17 @@ const emit = defineEmits<{ (e:'update:modelValue', v:string): void }>()
 </script>
 
 <template>
-  <div class="inline-flex overflow-hidden rounded-md border border-[var(--btn-border)] bg-[var(--surface)]">
+  <div class="inline-flex overflow-hidden rounded-[var(--radius-sm)] border border-[color:var(--btn-border)] bg-[color:var(--surface-translucent)] shadow-[var(--shadow-soft)] backdrop-blur-sm">
     <button
       v-for="opt in props.options"
       :key="opt.value"
       type="button"
       :class="[
-        'px-3 transition-colors',
-        props.size==='sm' ? 'py-1.5 text-sm' : 'py-2 text-sm',
-        props.modelValue===opt.value ? 'bg-[var(--accent)] text-white' : 'text-[var(--fg)] hover:bg-[var(--surface-2)]'
+        'px-3 transition-all duration-150 uppercase tracking-[0.14em] font-semibold border-r border-[color:var(--btn-border)] last:border-r-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--surface)]',
+        props.size==='sm' ? 'py-1.5 text-[0.62rem]' : 'py-2 text-[0.72rem]',
+        props.modelValue===opt.value
+          ? 'bg-[color:var(--accent)] text-[color:var(--bg)] shadow-[var(--shadow-button-hover)]'
+          : 'text-[color:var(--fg)] hover:bg-[color:var(--surface-veil)]'
       ]"
       @click="emit('update:modelValue', opt.value)"
     >

--- a/packages/ui/src/components/AppCard.vue
+++ b/packages/ui/src/components/AppCard.vue
@@ -3,7 +3,7 @@ defineProps<{ title?: string }>()
 </script>
 
 <template>
-  <section class="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm">
+  <section class="rounded-[var(--radius-lg)] border border-[color:var(--border)] bg-[color:var(--surface-panel)] p-5 shadow-[var(--shadow-card)] backdrop-blur-md">
     <h2 v-if="title" class="mb-3 text-base font-semibold">{{ title }}</h2>
     <slot />
   </section>

--- a/packages/ui/src/components/AppDropdown.vue
+++ b/packages/ui/src/components/AppDropdown.vue
@@ -31,11 +31,22 @@ function choose(v: string) {
 
 <template>
   <div ref="root" class="relative inline-flex">
-    <button :title="props.buttonTitle" type="button" @click="open = !open" class="inline-flex items-center gap-1 rounded-md border border-[var(--btn-border)] bg-[var(--btn-bg)] px-2.5 py-1.5 text-sm text-[var(--btn-fg)] hover:border-[var(--accent)]">
+    <button
+      :title="props.buttonTitle"
+      type="button"
+      @click="open = !open"
+      class="inline-flex items-center gap-2 rounded-[var(--radius-sm)] border border-[color:var(--btn-border)] bg-[color:var(--btn-bg)] px-3 py-2 text-[0.72rem] font-semibold uppercase tracking-[0.14em] text-[color:var(--btn-fg)] transition-all duration-200 shadow-[var(--shadow-button)] hover:border-[color:var(--accent)] hover:shadow-[var(--shadow-button-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--surface)]"
+    >
       <slot name="button" />
     </button>
-    <div v-if="open" :class="['absolute z-50 mt-2 w-48 overflow-hidden rounded-md border border-[var(--border)] bg-[var(--surface)] shadow-lg', props.align==='right' ? 'right-0' : 'left-0']">
-      <button v-for="it in props.items" :key="it.value" type="button" @click="choose(it.value)" class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-[var(--surface-2)]">
+    <div v-if="open" :class="['absolute z-50 mt-2 w-52 overflow-hidden rounded-[var(--radius-md)] border border-[color:var(--border)] bg-[color:var(--surface-panel)] shadow-[var(--shadow-elevated)] backdrop-blur-lg', props.align==='right' ? 'right-0' : 'left-0']">
+      <button
+        v-for="it in props.items"
+        :key="it.value"
+        type="button"
+        @click="choose(it.value)"
+        class="flex w-full items-center gap-3 px-3 py-2 text-left text-[0.72rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--fg)] transition-colors hover:bg-[color:var(--surface-veil)] focus-visible:outline-none focus-visible:bg-[color:var(--surface-veil)]"
+      >
         <AppIcon v-if="it.icon" :name="it.icon" />
         <span>{{ it.label }}</span>
       </button>

--- a/packages/ui/src/components/AppFieldLabel.vue
+++ b/packages/ui/src/components/AppFieldLabel.vue
@@ -4,7 +4,7 @@ const props = defineProps<{ icon?: 'sword'|'arrows'|'dice'|'book'|'info'; label:
 </script>
 
 <template>
-  <div class="mb-1 flex items-center gap-1 text-xs font-semibold uppercase text-[var(--muted)]">
+  <div class="mb-1 flex items-center gap-1 text-[0.62rem] font-semibold uppercase tracking-[0.28em] text-[color:var(--muted)]">
     <AppIcon v-if="props.icon" :name="props.icon" />
     <span>{{ props.label }}</span>
     <slot />

--- a/packages/ui/src/components/AppIconButton.vue
+++ b/packages/ui/src/components/AppIconButton.vue
@@ -7,15 +7,15 @@ const props = withDefaults(defineProps<{
   title?: string
 }>(), { variant: 'outline', size: 'sm', title: '' })
 
-const base = 'inline-flex items-center justify-center rounded-md border transition-colors select-none'
+const base = 'inline-flex items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--btn-border)] bg-[color:var(--btn-bg)] text-[color:var(--btn-fg)] transition-all duration-200 select-none shadow-[var(--shadow-button)] hover:border-[color:var(--accent)] hover:shadow-[var(--shadow-button-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-[color:var(--surface)] active:translate-y-[1px]'
 const sizes: Record<string, string> = { xs: 'h-7 w-7', sm: 'h-8 w-8', md: 'h-9 w-9' }
 const variants: Record<string, string> = {
-  default: 'bg-[var(--btn-bg)] text-[var(--btn-fg)] border-[var(--btn-border)] hover:border-[var(--accent)]',
-  primary: 'bg-[color:var(--accent)] text-white border-[color:var(--accent)] hover:opacity-90',
-  secondary: 'bg-[var(--surface-2)] text-[var(--fg)] border-[var(--border)] hover:border-[var(--accent)]',
-  danger: 'bg-red-600 text-white border-red-600 hover:opacity-90',
-  ghost: 'bg-transparent text-[var(--fg)] border-transparent hover:border-[var(--border)]',
-  outline: 'bg-transparent text-[var(--fg)] border-[var(--btn-border)] hover:border-[var(--accent)]',
+  default: '',
+  primary: 'bg-[color:var(--accent)] text-[color:var(--bg)] border-[color:var(--accent)] shadow-[var(--shadow-button-hover)] hover:shadow-[var(--shadow-button-hover)] focus-visible:ring-[color:var(--accent-strong)]',
+  secondary: 'bg-[color:var(--surface-veil)] text-[color:var(--fg)] border-[color:var(--border)]',
+  danger: 'bg-[#fb7185] text-white border-[#fb7185] shadow-[var(--shadow-button-hover)] focus-visible:ring-[rgba(251,113,133,0.5)]',
+  ghost: 'bg-transparent text-[color:var(--fg)] border-transparent shadow-none hover:border-[color:var(--border)] hover:bg-[color:var(--surface-translucent)] hover:shadow-none focus-visible:ring-[color:var(--accent-weak)]',
+  outline: 'bg-transparent text-[color:var(--fg)] border-[color:var(--border)] shadow-none hover:border-[color:var(--accent)] hover:shadow-none',
 }
 </script>
 

--- a/packages/ui/src/components/AppInput.vue
+++ b/packages/ui/src/components/AppInput.vue
@@ -10,13 +10,13 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{ (e: 'update:modelValue', v: any): void }>()
 
 const klass = computed(() => {
-  const base = 'w-full rounded-md border px-3 py-2 text-sm outline-none ring-0 transition-colors'
+  const base = 'w-full rounded-[var(--radius-sm)] border px-3 py-2 text-sm transition-all duration-150 text-[color:var(--fg)] placeholder:text-[color:var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--surface)]'
   const palette = props.variant === 'filled'
-    ? 'bg-[var(--surface-2)] text-[var(--fg)] border-[var(--border)] focus:border-[var(--accent)]'
+    ? 'bg-[color:var(--surface-veil)] border-[color:var(--border)]'
     : props.variant === 'ghost'
-    ? 'bg-transparent text-[var(--fg)] border-transparent focus:border-[var(--accent)]'
-    : 'bg-[var(--surface)] text-[var(--fg)] border-[var(--btn-border)] focus:border-[var(--accent)]'
-  const invalid = props.invalid ? 'border-red-500 focus:border-red-500' : ''
+    ? 'bg-transparent border-transparent focus-visible:border-[color:var(--accent)]'
+    : 'bg-[color:var(--surface-translucent)] border-[color:var(--btn-border)]'
+  const invalid = props.invalid ? 'border-[rgba(251,113,133,0.6)] focus-visible:ring-[rgba(251,113,133,0.4)] focus-visible:border-[rgba(251,113,133,0.9)]' : ''
   return [base, palette, invalid].join(' ')
 })
 </script>

--- a/packages/ui/src/components/AppSelect.vue
+++ b/packages/ui/src/components/AppSelect.vue
@@ -10,13 +10,13 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
 
 const klass = computed(() => {
-  const base = 'w-full rounded-md border px-2.5 py-2 text-sm outline-none ring-0 transition-colors'
+  const base = 'w-full rounded-[var(--radius-sm)] border px-2.5 py-2 text-sm transition-all duration-150 text-[color:var(--fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--surface)]'
   const palette = props.variant === 'filled'
-    ? 'bg-[var(--surface-2)] text-[var(--fg)] border-[var(--border)] focus:border-[var(--accent)]'
+    ? 'bg-[color:var(--surface-veil)] border-[color:var(--border)]'
     : props.variant === 'ghost'
-    ? 'bg-transparent text-[var(--fg)] border-transparent focus:border-[var(--accent)]'
-    : 'bg-[var(--surface)] text-[var(--fg)] border-[var(--btn-border)] focus:border-[var(--accent)]'
-  const invalid = props.invalid ? 'border-red-500 focus:border-red-500' : ''
+    ? 'bg-transparent border-transparent focus-visible:border-[color:var(--accent)] text-[color:var(--fg)]'
+    : 'bg-[color:var(--surface-translucent)] border-[color:var(--btn-border)] text-[color:var(--fg)]'
+  const invalid = props.invalid ? 'border-[rgba(251,113,133,0.6)] focus-visible:ring-[rgba(251,113,133,0.4)] focus-visible:border-[rgba(251,113,133,0.9)]' : ''
   return [base, palette, invalid].join(' ')
 })
 </script>

--- a/packages/ui/src/components/AppTagInput.vue
+++ b/packages/ui/src/components/AppTagInput.vue
@@ -44,10 +44,14 @@ function onKey(e: KeyboardEvent) {
 </script>
 
 <template>
-  <div class="flex flex-wrap items-center gap-1 rounded-md border border-[var(--btn-border)] bg-[var(--surface)] px-2 py-1">
+  <div class="flex flex-wrap items-center gap-1 rounded-[var(--radius-sm)] border border-[color:var(--btn-border)] bg-[color:var(--surface-translucent)] px-2.5 py-2 shadow-[var(--shadow-soft)]">
     <AppBadge v-for="(t, i) in tags" :key="t" variant="neutral">
       <span>{{ t }}</span>
-      <button type="button" class="ml-1 inline-flex rounded p-0.5 hover:bg-black/10 dark:hover:bg-white/10" @click="removeAt(i)">
+      <button
+        type="button"
+        class="ml-1 inline-flex items-center justify-center rounded-[var(--radius-xs)] p-0.5 text-[color:var(--muted)] transition-colors hover:bg-[color:var(--surface-veil)] hover:text-[color:var(--fg)]"
+        @click="removeAt(i)"
+      >
         <AppIcon name="x" />
       </button>
     </AppBadge>
@@ -55,7 +59,7 @@ function onKey(e: KeyboardEvent) {
       v-model="input"
       :placeholder="props.placeholder"
       @keydown="onKey"
-      class="flex-1 bg-transparent px-2 py-1 text-sm text-[var(--fg)] outline-none"
+      class="flex-1 bg-transparent px-2 py-1 text-sm text-[color:var(--fg)] placeholder:text-[color:var(--muted)] focus-visible:outline-none"
     />
   </div>
 </template>

--- a/packages/ui/src/components/AppText.vue
+++ b/packages/ui/src/components/AppText.vue
@@ -6,12 +6,12 @@ const props = withDefaults(defineProps<{
 }>(), { as: 'p', variant: 'body', class: '' })
 
 const map: Record<string, string> = {
-  body: 'text-[var(--fg)]',
-  muted: 'text-[var(--muted)]',
-  caption: 'text-xs text-[var(--muted)] uppercase tracking-wide',
-  mono: 'font-mono',
-  small: 'text-sm',
-  lead: 'text-base text-[var(--muted)]',
+  body: 'text-[color:var(--fg)] leading-relaxed',
+  muted: 'text-[color:var(--muted)] leading-relaxed',
+  caption: 'text-[0.62rem] uppercase tracking-[0.32em] text-[color:var(--muted)]',
+  mono: 'font-mono text-sm text-[color:var(--accent-strong)]',
+  small: 'text-sm text-[color:var(--fg)]',
+  lead: 'text-base text-[color:var(--accent-weak)]',
 }
 </script>
 

--- a/packages/ui/src/components/AppTextarea.vue
+++ b/packages/ui/src/components/AppTextarea.vue
@@ -10,13 +10,13 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
 
 const klass = computed(() => {
-  const base = 'w-full rounded-md border px-3 py-2 text-sm outline-none ring-0 transition-colors'
+  const base = 'w-full rounded-[var(--radius-sm)] border px-3 py-2 text-sm transition-all duration-150 text-[color:var(--fg)] placeholder:text-[color:var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--surface)]'
   const palette = props.variant === 'filled'
-    ? 'bg-[var(--surface-2)] text-[var(--fg)] border-[var(--border)] focus:border-[var(--accent)]'
+    ? 'bg-[color:var(--surface-veil)] border-[color:var(--border)]'
     : props.variant === 'ghost'
-    ? 'bg-transparent text-[var(--fg)] border-transparent focus:border-[var(--accent)]'
-    : 'bg-[var(--surface)] text-[var(--fg)] border-[var(--btn-border)] focus:border-[var(--accent)]'
-  const invalid = props.invalid ? 'border-red-500 focus:border-red-500' : ''
+    ? 'bg-transparent border-transparent focus-visible:border-[color:var(--accent)]'
+    : 'bg-[color:var(--surface-translucent)] border-[color:var(--btn-border)]'
+  const invalid = props.invalid ? 'border-[rgba(251,113,133,0.6)] focus-visible:ring-[rgba(251,113,133,0.4)] focus-visible:border-[rgba(251,113,133,0.9)]' : ''
   return [base, palette, invalid].join(' ')
 })
 </script>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,3 +13,5 @@ export { default as AppSelect } from './components/AppSelect.vue'
 export { default as AppTagInput } from './components/AppTagInput.vue'
 export { default as AppText } from './components/AppText.vue'
 export { default as AppTextarea } from './components/AppTextarea.vue'
+
+export * from '@my-monorepo/design-tokens'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   apps/daggerheart-statblock-builder:
     dependencies:
+      '@my-monorepo/theme':
+        specifier: workspace:*
+        version: link:../../packages/theme
       '@my-monorepo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -57,6 +60,9 @@ importers:
 
   apps/helianas-recipe-search:
     dependencies:
+      '@my-monorepo/theme':
+        specifier: workspace:*
+        version: link:../../packages/theme
       minisearch:
         specifier: ^7.1.0
         version: 7.2.0
@@ -82,6 +88,9 @@ importers:
 
   apps/mapbox-pokemon-battler:
     dependencies:
+      '@my-monorepo/theme':
+        specifier: workspace:*
+        version: link:../../packages/theme
       mapbox-gl:
         specifier: ^3.9.0
         version: 3.15.0
@@ -128,6 +137,9 @@ importers:
 
   apps/mapbox-weather-vis:
     dependencies:
+      '@my-monorepo/theme':
+        specifier: workspace:*
+        version: link:../../packages/theme
       mapbox-gl:
         specifier: ^3.9.0
         version: 3.15.0
@@ -156,9 +168,21 @@ importers:
 
   packages/ui:
     dependencies:
+      '@my-monorepo/design-tokens':
+        specifier: workspace:*
+        version: link:../design-tokens
       vue:
         specifier: ^3.5.0
         version: 3.5.21(typescript@5.8.3)
+
+  packages/design-tokens:
+    dependencies: {}
+
+  packages/theme:
+    dependencies:
+      '@my-monorepo/design-tokens':
+        specifier: workspace:*
+        version: link:../design-tokens
 
 packages:
 


### PR DESCRIPTION
## Summary
- add shared design token and theme workspace packages that expose neon-forward variables and helpers
- restyle UI kit components to leverage the shared tokens and cyberpunk palette
- wire the new global theme styles into each app and refresh local layouts to match

## Testing
- pnpm install
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d53a837988832f9ea5ec2ee306caaa