### PR TITLE
Revamp daggerheart builder with modal wizard UI

### DIFF
--- a/apps/daggerheart-statblock-builder/src/App.vue
+++ b/apps/daggerheart-statblock-builder/src/App.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { AppButton, AppCard, AppIconButton } from '@my-monorepo/ui'
 import WizardBuilder from './components/WizardBuilder.vue'
 import StatblockPreview from './components/StatblockPreview.vue'
 import Toolbar from './components/Toolbar.vue'
 import PrintableStatblock from './components/PrintableStatblock.vue'
 import GlossaryDrawer from './components/GlossaryDrawer.vue'
 import { useStatblockBuilder } from './composables/useStatblockBuilder'
+import { getTierGuide } from './lib/tierGuides'
 
 const {
   sbType,
@@ -20,34 +23,182 @@ const {
   resetAll,
   loadPreset
 } = useStatblockBuilder()
+
+const showWizard = ref(false)
+const wizardKey = ref(0)
+
+const isEnemy = computed(() => sbType.value === 'enemy')
+const displayName = computed(() => {
+  const label = (name.value || '').trim()
+  if (label) return label
+  return isEnemy.value ? 'Untitled Enemy' : 'Untitled Environment'
+})
+
+const tierGuide = computed(() => (tier.value != null ? getTierGuide(tier.value) : null))
+
+const summaryMeta = computed(() => {
+  const items: Array<{ label: string; value: string }> = [
+    { label: 'Type', value: isEnemy.value ? 'Enemy' : 'Environment' },
+    { label: 'Tier', value: tier.value != null ? `Tier ${tier.value}` : 'Unassigned' }
+  ]
+
+  if (isEnemy.value) {
+    if (enemy.rank) items.push({ label: 'Rank', value: enemy.rank })
+    if (enemy.difficulty != null) items.push({ label: 'Difficulty', value: String(enemy.difficulty) })
+    if (enemy.hp != null) items.push({ label: 'HP', value: String(enemy.hp) })
+    if (enemy.stress != null) items.push({ label: 'Stress', value: String(enemy.stress) })
+  } else {
+    if (environment.category) items.push({ label: 'Category', value: environment.category })
+    if (environment.difficulty != null) items.push({ label: 'Difficulty', value: String(environment.difficulty) })
+    if (environment.impulses) items.push({ label: 'Impulses', value: environment.impulses })
+  }
+
+  return items
+})
+
+const summaryMessage = computed(() => {
+  if (tierGuide.value) {
+    return `You're building for ${tierGuide.value.title.toLowerCase()}. Dial in the stats with the guided steps for a balanced encounter.`
+  }
+  return 'Kick things off by selecting a tier — the guided steps will help you fill in everything that matters.'
+})
+
+function openWizard() {
+  showWizard.value = true
+}
+
+function closeWizard() {
+  showWizard.value = false
+  wizardKey.value += 1
+}
+
+function handleFinish() {
+  closeWizard()
+}
+
+watch(
+  () => showWizard.value,
+  (open) => {
+    document.body.style.setProperty('overflow', open ? 'hidden' : '')
+  }
+)
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && showWizard.value) {
+    event.preventDefault()
+    closeWizard()
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', onKeydown)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown)
+  document.body.style.removeProperty('overflow')
+})
 </script>
 
 <template>
-  <div class="mx-auto max-w-6xl px-4 py-6">
-    <header class="mb-3">
-      <h1 class="m-0 text-xl font-semibold">Daggerheart Statblock Builder</h1>
-      <p class="m-0 mt-1 text-[color:var(--muted)]">Create Enemy or Environment statblocks. Shared fields + type-specific details.</p>
-    </header>
+  <div class="app-wrapper">
+    <div class="app-backdrop" aria-hidden="true" />
 
-    <Toolbar :sbType="sbType" :enemy="enemy" :environment="environment" :theme="theme" @update:theme="setTheme" @reset="resetAll" @load-preset="loadPreset" class="toolbar topbar" />
+    <div class="app-container">
+      <header class="hero-card glass-panel">
+        <div class="hero-content">
+          <p class="eyebrow">Currently editing</p>
+          <h1>{{ displayName }}</h1>
+          <p class="lead">{{ summaryMessage }}</p>
+          <div v-if="summaryMeta.length" class="hero-meta">
+            <div v-for="item in summaryMeta" :key="item.label" class="hero-chip">
+              <span class="label">{{ item.label }}</span>
+              <span class="value">{{ item.value }}</span>
+            </div>
+          </div>
+          <div class="hero-actions">
+            <AppButton size="lg" variant="primary" @click="openWizard">Launch guided builder</AppButton>
+            <AppButton size="lg" variant="subtle" @click="resetAll">Start fresh</AppButton>
+          </div>
+          <p class="meta-note">Saved automatically — export whenever you're ready using the toolbar below.</p>
+        </div>
+      </header>
 
-    <div class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
-      <div>
-        <WizardBuilder
-          v-model:sbType="sbType"
-          v-model:name="name"
-          v-model:archetype="archetype"
-          v-model:tier="tier"
-          v-model:description="description"
-          v-model:traits="traits"
-          :enemy="enemy"
-          :environment="environment"
-        />
-      </div>
-      <div>
-        <StatblockPreview :sbType="sbType" :enemy="enemy" :environment="environment" />
-      </div>
+      <Toolbar
+        class="topbar glass-panel"
+        :sbType="sbType"
+        :enemy="enemy"
+        :environment="environment"
+        :theme="theme"
+        @update:theme="setTheme"
+        @reset="resetAll"
+        @load-preset="loadPreset"
+      />
+
+      <main class="content-grid">
+        <section class="info-stack">
+          <AppCard padding="lg" class="glass-panel">
+            <h2 class="section-title">Quick summary</h2>
+            <p class="section-subtitle">Use the guided modal to capture every detail. This panel updates as you go.</p>
+            <div v-if="summaryMeta.length" class="summary-grid">
+              <div v-for="item in summaryMeta" :key="item.label" class="summary-item">
+                <span class="summary-label">{{ item.label }}</span>
+                <span class="summary-value">{{ item.value }}</span>
+              </div>
+            </div>
+            <p v-else class="empty-state">No details yet — open the builder to get started.</p>
+          </AppCard>
+
+          <AppCard padding="lg" class="glass-panel">
+            <h2 class="section-title">Workflow tips</h2>
+            <ul class="tips-list">
+              <li>Step through the wizard to keep vital stats grouped by purpose.</li>
+              <li>Switch between enemy and environment tiers without losing progress.</li>
+              <li>Use the glossary from the toolbar whenever you need official wording.</li>
+            </ul>
+          </AppCard>
+        </section>
+
+        <section class="preview-column">
+          <StatblockPreview :sbType="sbType" :enemy="enemy" :environment="environment" />
+        </section>
+      </main>
     </div>
+
+    <Transition name="wizard-fade">
+      <div
+        v-if="showWizard"
+        class="wizard-overlay"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Daggerheart statblock builder"
+        @click.self="closeWizard"
+      >
+        <div class="wizard-dialog glass-panel">
+          <header class="wizard-header">
+            <div>
+              <p class="eyebrow">Guided builder</p>
+              <h2>{{ displayName }}</h2>
+            </div>
+            <AppIconButton name="x" variant="outline" title="Close builder" @click="closeWizard" />
+          </header>
+          <div class="wizard-body">
+            <WizardBuilder
+              :key="wizardKey"
+              v-model:sbType="sbType"
+              v-model:name="name"
+              v-model:archetype="archetype"
+              v-model:tier="tier"
+              v-model:description="description"
+              v-model:traits="traits"
+              :enemy="enemy"
+              :environment="environment"
+              @finish="handleFinish"
+            />
+          </div>
+        </div>
+      </div>
+    </Transition>
 
     <div class="print-only">
       <PrintableStatblock :sbType="sbType" :enemy="enemy" :environment="environment" />
@@ -56,3 +207,274 @@ const {
   </div>
 </template>
 
+<style scoped>
+.app-wrapper {
+  position: relative;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, color-mix(in srgb, var(--accent) 10%, transparent), transparent 55%),
+    var(--bg);
+  padding-bottom: 4rem;
+}
+
+.app-backdrop {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, color-mix(in srgb, var(--accent) 14%, transparent), transparent 60%);
+  opacity: 0.35;
+  filter: saturate(120%);
+  pointer-events: none;
+}
+
+.app-container {
+  position: relative;
+  z-index: 1;
+  margin: 0 auto;
+  max-width: 1120px;
+  padding: 3.5rem 1.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.glass-panel {
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  background: color-mix(in srgb, var(--surface-translucent) 88%, transparent);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(18px);
+}
+
+.hero-card {
+  padding: 2.5rem 2.25rem;
+}
+
+.hero-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw + 1rem, 2.5rem);
+  font-weight: 700;
+}
+
+.lead {
+  margin: 0;
+  color: color-mix(in srgb, var(--muted) 90%, transparent);
+  font-size: 1rem;
+  max-width: 36rem;
+}
+
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero-chip {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--btn-border) 70%, transparent);
+  background: color-mix(in srgb, var(--surface-veil) 75%, transparent);
+}
+
+.hero-chip .label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: color-mix(in srgb, var(--muted) 86%, transparent);
+}
+
+.hero-chip .value {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.meta-note {
+  margin: 0;
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+  font-size: 0.85rem;
+}
+
+.content-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.info-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.section-subtitle {
+  margin: 0.35rem 0 1.25rem;
+  color: color-mix(in srgb, var(--muted) 90%, transparent);
+  font-size: 0.9rem;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-veil) 75%, transparent);
+  border: 1px solid color-mix(in srgb, var(--btn-border) 60%, transparent);
+}
+
+.summary-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 80%, transparent);
+}
+
+.summary-value {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.empty-state {
+  margin: 0;
+  color: color-mix(in srgb, var(--muted) 88%, transparent);
+}
+
+.tips-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
+}
+
+.preview-column {
+  position: sticky;
+  top: 1.5rem;
+  align-self: flex-start;
+}
+
+.wizard-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(1rem, 4vw, 2.5rem);
+  background: color-mix(in srgb, var(--surface-translucent) 82%, rgba(10, 10, 18, 0.55));
+  backdrop-filter: blur(22px);
+  z-index: 50;
+}
+
+.wizard-dialog {
+  width: min(1120px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.75rem;
+}
+
+.wizard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  padding-bottom: 1rem;
+}
+
+.wizard-body {
+  flex: 1;
+  min-height: 0;
+}
+
+.wizard-body :deep(.wizard-shell) {
+  height: 100%;
+}
+
+.print-only {
+  display: none;
+}
+
+.wizard-fade-enter-active,
+.wizard-fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.wizard-fade-enter-from,
+.wizard-fade-leave-to {
+  opacity: 0;
+  transform: scale(0.98);
+}
+
+@media (min-width: 980px) {
+  .content-grid {
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .app-container {
+    padding-inline: 1rem;
+    padding-top: 2.5rem;
+  }
+
+  .hero-card {
+    padding: 2rem 1.5rem;
+  }
+
+  .preview-column {
+    position: static;
+  }
+
+  .wizard-dialog {
+    padding: 1.25rem;
+  }
+}
+
+@media print {
+  .app-container,
+  .wizard-overlay,
+  .glass-panel {
+    display: none !important;
+  }
+
+  .print-only {
+    display: block !important;
+  }
+}
+</style>

--- a/apps/daggerheart-statblock-builder/src/components/StatblockPreview.vue
+++ b/apps/daggerheart-statblock-builder/src/components/StatblockPreview.vue
@@ -3,88 +3,384 @@ import { computed } from 'vue'
 import type { Enemy, Environment } from '../types'
 import { AppBadge, AppCard, AppText } from '@my-monorepo/ui'
 import { getTierGuide } from '../lib/tierGuides'
+
 const props = defineProps<{
   sbType: 'enemy' | 'environment'
   enemy: Enemy
   environment: Environment
 }>()
 
+const isEnemy = computed(() => props.sbType === 'enemy')
+const enemyData = computed(() => props.enemy)
+const environmentData = computed(() => props.environment)
+
+const activeBlock = computed(() => (isEnemy.value ? enemyData.value : environmentData.value))
+
 const title = computed(() => {
-  const isEnemy = props.sbType === 'enemy'
-  const sb = isEnemy ? props.enemy : props.environment
-  const parts = [sb.name || (isEnemy ? 'New Enemy' : 'New Environment')]
-  if (sb.tier != null && sb.tier !== ('' as any)) {
-    const info = getTierGuide(sb.tier as number)
-    parts.push(`— ${info ? info.title : `Tier ${sb.tier}`}`)
-  }
-  if (isEnemy && props.enemy.rank) parts.push(props.enemy.rank)
-  if (!isEnemy && props.environment.category) parts.push(props.environment.category)
-  return parts.join(' ')
+  const base = (activeBlock.value.name || '').trim()
+  if (base) return base
+  return isEnemy.value ? 'New Enemy' : 'New Environment'
 })
 
-const archetype = computed(() => {
-  const isEnemy = props.sbType === 'enemy'
-  const sb = isEnemy ? props.enemy : props.environment
-  return sb.archetype
+const subtitle = computed(() => (activeBlock.value.archetype || '').trim())
+const description = computed(() => (activeBlock.value.description || '').trim())
+
+const tierInfo = computed(() => {
+  const tier = activeBlock.value.tier as number | null
+  if (tier != null && tier !== ('' as any)) {
+    return getTierGuide(Number(tier))
+  }
+  return null
+})
+
+const traits = computed(() => {
+  const value = activeBlock.value.traits || ''
+  return value
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean)
+})
+
+const metaStats = computed(() => {
+  const items: Array<{ label: string; value: string; hint?: string }> = []
+  const tierLabel = tierInfo.value ? `Tier ${tierInfo.value.tier}` : 'Unassigned'
+  items.push({ label: 'Tier', value: tierLabel, hint: tierInfo.value?.title })
+
+  if (isEnemy.value) {
+    const enemy = enemyData.value
+    items.push({ label: 'Rank', value: enemy.rank || '—' })
+    items.push({ label: 'Difficulty', value: enemy.difficulty != null ? String(enemy.difficulty) : '—' })
+    items.push({ label: 'HP', value: enemy.hp != null ? String(enemy.hp) : '—' })
+    items.push({ label: 'Stress', value: enemy.stress != null ? String(enemy.stress) : '—' })
+    items.push({ label: 'Thresholds', value: enemy.thresholds || '—' })
+    if (enemy.atkBonus != null) {
+      items.push({ label: 'Attack Bonus', value: `+${enemy.atkBonus}` })
+    }
+  } else {
+    const env = environmentData.value
+    items.push({ label: 'Category', value: env.category || '—' })
+    items.push({ label: 'Difficulty', value: env.difficulty != null ? String(env.difficulty) : '—' })
+    items.push({ label: 'Impulses', value: env.impulses || '—' })
+    if (env.potential) {
+      items.push({ label: 'Potential Adversaries', value: env.potential })
+    }
+  }
+
+  return items
+})
+
+const hasDetailContent = computed(() => {
+  if (isEnemy.value) {
+    const enemy = enemyData.value
+    return (
+      enemy.attacks.length > 0 ||
+      enemy.features.length > 0 ||
+      Boolean(enemy.experience) ||
+      Boolean(enemy.tactics)
+    )
+  }
+
+  const env = environmentData.value
+  return env.features.length > 0 || Boolean(env.prompts)
 })
 </script>
 
 <template>
-  <AppCard :title="'Preview'" variant="elevated" padding="md">
-    <div>
-      <h3 class="mb-2 mt-1 text-base font-semibold">{{ title }}</h3>
-      <p v-if="archetype" class="m-0 text-sm italic text-[color:var(--muted)]">{{ archetype }}</p>
-      <AppText v-if="(props.sbType==='enemy' ? props.enemy.description : props.environment.description)" variant="lead" class="mt-1">
-        {{ props.sbType==='enemy' ? props.enemy.description : props.environment.description }}
-      </AppText>
-      <div v-if="(props.sbType==='enemy' ? props.enemy.traits : props.environment.traits)" class="mt-1 flex flex-wrap gap-1">
-        <AppBadge v-for="t in (props.sbType==='enemy' ? props.enemy.traits : props.environment.traits).split(',').map(s=>s.trim()).filter(Boolean)" :key="t" variant="neutral">{{ t }}</AppBadge>
+  <AppCard padding="lg" class="preview-card">
+    <header class="preview-header">
+      <div>
+        <p class="preview-eyebrow">{{ isEnemy ? 'Enemy statblock' : 'Environment statblock' }}</p>
+        <h2 class="preview-title">{{ title }}</h2>
+        <p v-if="subtitle" class="preview-subtitle">{{ subtitle }}</p>
       </div>
+      <div class="preview-badges">
+        <AppBadge variant="accent">{{ tierInfo ? tierInfo.title : 'Tier pending' }}</AppBadge>
+        <AppBadge variant="neutral">{{ isEnemy ? 'Enemy' : 'Environment' }}</AppBadge>
+      </div>
+    </header>
 
-      <template v-if="props.sbType==='enemy'">
-            <p style="margin:.25rem 0;">Difficulty: {{ props.enemy.difficulty ?? '—' }} | Thresholds: {{ props.enemy.thresholds || '—' }} | HP: {{ props.enemy.hp ?? '—' }} | Stress: {{ props.enemy.stress ?? '—' }}</p>
-            <p v-if="props.enemy.atkBonus != null" style="margin:.25rem 0;">ATK: +{{ props.enemy.atkBonus }}</p>
-            <div v-if="props.enemy.attacks.length" style="margin:.25rem 0;">
-              <div v-for="a in props.enemy.attacks" :key="a.id" class="flex items-center gap-2">
-                <strong>{{ a.name || '—' }}</strong>
-                <AppBadge variant="accent">{{ a.range || '—' }}</AppBadge>
-                <span class="font-mono">{{ a.details || '—' }}</span>
-              </div>
-            </div>
-        <p v-if="props.enemy.experience" style="margin:.25rem 0;">Experience: {{ props.enemy.experience }}</p>
-        <p v-if="props.enemy.tactics" style="margin:.25rem 0;">Motives & Tactics: {{ props.enemy.tactics }}</p>
-        <div v-if="props.enemy.features.length" style="margin-top:.5rem;">
-          <h4 style="margin:.25rem 0;">Features</h4>
-          <div v-for="f in props.enemy.features" :key="f.id" style="margin:.25rem 0;">
-            <strong>{{ f.name || '—' }}</strong>
-            <span v-if="f.tag"> - {{ f.tag }}</span>
-            <span v-if="f.cost">: {{ f.cost }}</span>
-            <div v-if="f.text">
-              <pre style="white-space:pre-wrap; margin:.25rem 0 0;">{{ f.text }}</pre>
-            </div>
-          </div>
-        </div>
-      </template>
-      <template v-else>
-        <p style="margin:.25rem 0;">Difficulty: {{ props.environment.difficulty ?? '—' }}</p>
-        <p v-if="props.environment.impulses" style="margin:.25rem 0;">Impulses: {{ props.environment.impulses }}</p>
-        <div v-if="props.environment.features.length" style="margin-top:.5rem;">
-          <h4 style="margin:.25rem 0;">Features</h4>
-          <div v-for="f in props.environment.features" :key="f.id" style="margin:.25rem 0;">
-            <strong>{{ f.name || '—' }}</strong>
-            <span v-if="f.tag"> - {{ f.tag }}</span>
-            <span v-if="f.cost">: {{ f.cost }}</span>
-            <div v-if="f.text">
-              <pre style="white-space:pre-wrap; margin:.25rem 0 0;">{{ f.text }}</pre>
-            </div>
-          </div>
-        </div>
-        <p v-if="props.environment.potential" style="margin:.25rem 0;">Potential Adversaries: {{ props.environment.potential }}</p>
-        <div v-if="props.environment.prompts">
-          <h4 style="margin:.25rem 0;">GM Prompts</h4>
-          <pre style="white-space:pre-wrap; margin:.25rem 0 0;">{{ props.environment.prompts }}</pre>
-        </div>
-      </template>
+    <AppText v-if="description" variant="lead" class="preview-description">{{ description }}</AppText>
+
+    <div v-if="traits.length" class="preview-traits">
+      <AppBadge v-for="trait in traits" :key="trait" variant="neutral">{{ trait }}</AppBadge>
     </div>
+
+    <div v-if="metaStats.length" class="preview-meta">
+      <div v-for="item in metaStats" :key="item.label" class="meta-card">
+        <span class="meta-label">{{ item.label }}</span>
+        <span class="meta-value">{{ item.value }}</span>
+        <span v-if="item.hint" class="meta-hint">{{ item.hint }}</span>
+      </div>
+    </div>
+
+    <template v-if="isEnemy">
+      <section v-if="enemyData.attacks.length" class="detail-section">
+        <h3>Attacks</h3>
+        <div class="attack-list">
+          <div v-for="attack in enemyData.attacks" :key="attack.id" class="attack-item">
+            <div class="attack-heading">
+              <span class="attack-name">{{ attack.name || 'Unnamed attack' }}</span>
+              <AppBadge v-if="attack.range" variant="accent">{{ attack.range }}</AppBadge>
+            </div>
+            <p v-if="attack.details" class="attack-details">{{ attack.details }}</p>
+          </div>
+        </div>
+      </section>
+
+      <section v-if="enemyData.features.length" class="detail-section">
+        <h3>Features</h3>
+        <div class="feature-list">
+          <div v-for="feature in enemyData.features" :key="feature.id" class="feature-item">
+            <div class="feature-head">
+              <span class="feature-name">{{ feature.name || 'Unnamed feature' }}</span>
+              <span v-if="feature.tag" class="feature-pill">{{ feature.tag }}</span>
+              <span v-if="feature.cost" class="feature-pill muted">{{ feature.cost }}</span>
+            </div>
+            <p v-if="feature.text" class="feature-text">{{ feature.text }}</p>
+          </div>
+        </div>
+      </section>
+
+      <section v-if="enemyData.experience || enemyData.tactics" class="detail-section info-grid">
+        <div v-if="enemyData.experience" class="info-card">
+          <h4>Experience</h4>
+          <p>{{ enemyData.experience }}</p>
+        </div>
+        <div v-if="enemyData.tactics" class="info-card">
+          <h4>Motives &amp; Tactics</h4>
+          <p>{{ enemyData.tactics }}</p>
+        </div>
+      </section>
+    </template>
+
+    <template v-else>
+      <section v-if="environmentData.features.length" class="detail-section">
+        <h3>Features</h3>
+        <div class="feature-list">
+          <div v-for="feature in environmentData.features" :key="feature.id" class="feature-item">
+            <div class="feature-head">
+              <span class="feature-name">{{ feature.name || 'Unnamed feature' }}</span>
+              <span v-if="feature.tag" class="feature-pill">{{ feature.tag }}</span>
+              <span v-if="feature.cost" class="feature-pill muted">{{ feature.cost }}</span>
+            </div>
+            <p v-if="feature.text" class="feature-text">{{ feature.text }}</p>
+          </div>
+        </div>
+      </section>
+
+      <section v-if="environmentData.prompts" class="detail-section">
+        <h3>GM Prompts</h3>
+        <pre class="prompt-text">{{ environmentData.prompts }}</pre>
+      </section>
+    </template>
+
+    <p v-if="!hasDetailContent" class="preview-placeholder">
+      Add more details in the guided builder to see them reflected here.
+    </p>
   </AppCard>
 </template>
+
+<style scoped>
+.preview-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.preview-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.preview-eyebrow {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+}
+
+.preview-title {
+  margin: 0.2rem 0 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.preview-subtitle {
+  margin: 0.25rem 0 0;
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
+  font-style: italic;
+}
+
+.preview-badges {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.preview-description {
+  margin-top: 0.25rem;
+}
+
+.preview-traits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.preview-meta {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.meta-card {
+  padding: 0.75rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-veil) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--btn-border) 60%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.meta-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
+}
+
+.meta-value {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.meta-hint {
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--muted) 80%, transparent);
+}
+
+.detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.detail-section h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.attack-list,
+.feature-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.attack-item,
+.feature-item {
+  padding: 0.75rem 0.85rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-veil) 75%, transparent);
+  border: 1px solid color-mix(in srgb, var(--btn-border) 58%, transparent);
+}
+
+.attack-heading,
+.feature-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.attack-name,
+.feature-name {
+  font-weight: 600;
+}
+
+.attack-details,
+.feature-text {
+  margin: 0.4rem 0 0;
+  white-space: pre-line;
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
+  font-size: 0.9rem;
+}
+
+.feature-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.5rem;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: color-mix(in srgb, var(--accent) 90%, transparent);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.feature-pill.muted {
+  background: color-mix(in srgb, var(--surface-veil) 70%, transparent);
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+}
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.info-card {
+  padding: 0.95rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-veil) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--btn-border) 55%, transparent);
+}
+
+.info-card h4 {
+  margin: 0 0 0.45rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.info-card p {
+  margin: 0;
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
+  white-space: pre-line;
+}
+
+.prompt-text {
+  margin: 0;
+  padding: 0.95rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-veil) 76%, transparent);
+  border: 1px solid color-mix(in srgb, var(--btn-border) 58%, transparent);
+  white-space: pre-wrap;
+  font-size: 0.92rem;
+}
+
+.preview-placeholder {
+  margin: 0;
+  padding: 0.75rem 0.85rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-veil) 72%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--btn-border) 58%, transparent);
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+  text-align: center;
+  font-size: 0.88rem;
+}
+
+@media (max-width: 600px) {
+  .preview-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .preview-badges {
+    flex-direction: row;
+  }
+}
+</style>

--- a/apps/daggerheart-statblock-builder/src/components/WizardBuilder.vue
+++ b/apps/daggerheart-statblock-builder/src/components/WizardBuilder.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { computed, ref } from 'vue'
 import BaseDetailsForm from './BaseDetailsForm.vue'
 import TierSelectionStep from './TierSelectionStep.vue'
 import EnemyProfileForm from './EnemyProfileForm.vue'
@@ -8,7 +8,14 @@ import EnvironmentProfileForm from './EnvironmentProfileForm.vue'
 import EnvironmentFeaturesForm from './EnvironmentFeaturesForm.vue'
 import type { Enemy, Environment } from '../types'
 import { fadeSlideUp } from '@my-monorepo/ui'
-import { AppButton, AppCard, AppIcon } from '@my-monorepo/ui'
+import { AppButton, AppIcon } from '@my-monorepo/ui'
+
+type StepKey = 'tier' | 'identity' | 'profile' | 'abilities' | 'review'
+type StepDefinition = {
+  key: StepKey
+  label: string
+  icon: 'info' | 'book' | 'sword' | 'palette' | 'print'
+}
 
 const props = defineProps<{
   sbType: 'enemy' | 'environment'
@@ -28,47 +35,124 @@ const emit = defineEmits<{
   (e: 'update:tier', v: number | null): void
   (e: 'update:description', v: string): void
   (e: 'update:traits', v: string): void
+  (e: 'finish'): void
 }>()
 
 const current = ref(0)
-const steps = computed(() => [
-  { key: 'tier', label: 'Tier', icon: 'info' as const },
-  { key: 'identity', label: 'Identity', icon: 'book' as const },
+
+const isEnemy = computed(() => props.sbType === 'enemy')
+
+const steps = computed<StepDefinition[]>(() => [
+  { key: 'tier', label: 'Tier', icon: 'info' },
+  { key: 'identity', label: 'Identity', icon: 'book' },
   {
     key: 'profile',
-    label: props.sbType === 'enemy' ? 'Threat' : 'Profile',
-    icon: props.sbType === 'enemy' ? ('sword' as const) : ('book' as const)
+    label: isEnemy.value ? 'Threat Profile' : 'Environment Profile',
+    icon: isEnemy.value ? 'sword' : 'book'
   },
   {
     key: 'abilities',
-    label: props.sbType === 'enemy' ? 'Abilities' : 'Features',
-    icon: 'palette' as const
+    label: isEnemy.value ? 'Abilities' : 'Features',
+    icon: 'palette'
   },
-  { key: 'review', label: 'Review', icon: 'print' as const },
+  { key: 'review', label: 'Review', icon: 'print' }
 ])
 
-function next() { if (current.value < steps.value.length - 1) current.value++ }
-function back() { if (current.value > 0) current.value-- }
-function goto(i: number) { current.value = i }
+const stepCopy = computed<Record<StepKey, { short: string; detail: string }>>(() => ({
+  tier: {
+    short: 'Select tier & statblock type',
+    detail: 'Choose the encounter tier and whether you are building an enemy or environment.'
+  },
+  identity: {
+    short: 'Describe the identity',
+    detail: 'Give the statblock a name, archetype, summary, and traits to set the tone.'
+  },
+  profile: isEnemy.value
+    ? {
+        short: 'Dial in the threat profile',
+        detail: 'Tune difficulty, thresholds, HP, and stress to match the tier guidance.'
+      }
+    : {
+        short: 'Shape the environment profile',
+        detail: 'Outline category, difficulty, impulses, and core identity of the scene.'
+      },
+  abilities: isEnemy.value
+    ? {
+        short: 'Craft signature abilities',
+        detail: 'Add attacks, experience notes, and features that define the enemy encounter.'
+      }
+    : {
+        short: 'Describe features and prompts',
+        detail: 'Capture features, prompts, and potential adversaries that bring the environment to life.'
+      },
+  review: {
+    short: 'Review & final touches',
+    detail: 'Cross-check your work in the live preview and prepare for export.'
+  }
+}))
+
+const activeCopy = computed(() => {
+  const activeStep = steps.value[current.value]
+  if (!activeStep) return { short: '', detail: '' }
+  return stepCopy.value[activeStep.key]
+})
+
+function next() {
+  if (current.value < steps.value.length - 1) {
+    current.value++
+    return
+  }
+  emit('finish')
+}
+
+function back() {
+  if (current.value > 0) current.value--
+}
+
+function goto(i: number) {
+  current.value = i
+}
 
 const atFirst = computed(() => current.value === 0)
 const atLast = computed(() => current.value === steps.value.length - 1)
+const progress = computed(() => Math.round(((current.value + 1) / steps.value.length) * 100))
 </script>
 
 <template>
-  <div>
-    <AppCard variant="elevated" padding="md">
-      <div class="mb-3 flex flex-wrap items-center gap-2">
-        <button
-          v-for="(s, i) in steps"
-          :key="s.key"
-          type="button"
-          :class="['inline-flex items-center gap-2 rounded-[var(--radius-pill)] border px-3 py-1 text-[0.72rem] font-semibold uppercase tracking-[0.14em] transition-colors', i===current ? 'bg-[color:var(--accent)] text-[color:var(--bg)] border-[color:var(--accent)]' : 'text-[color:var(--fg)] border-[color:var(--btn-border)] hover:bg-[color:var(--surface-veil)]']"
-          @click="goto(i)"
-        >
-          <AppIcon :name="s.icon" size="sm" :color="i===current ? 'bg' : 'fg'" />
-          <span>{{ s.label }}</span>
-        </button>
+  <div class="wizard-shell">
+    <aside class="wizard-sidebar">
+      <div class="sidebar-copy">
+        <p class="step-count">Step {{ current + 1 }} of {{ steps.length }}</p>
+        <h3 class="sidebar-title">{{ steps[current].label }}</h3>
+        <p class="sidebar-detail">{{ activeCopy.detail }}</p>
+      </div>
+      <ol class="stepper" role="list">
+        <li v-for="(s, i) in steps" :key="s.key">
+          <button
+            type="button"
+            class="stepper-item"
+            :class="{ active: i === current, complete: i < current }"
+            @click="goto(i)"
+          >
+            <span class="indicator" :aria-label="`Step ${i + 1}`">
+              <span v-if="i < current" class="checkmark">✓</span>
+              <span v-else>{{ i + 1 }}</span>
+            </span>
+            <span class="stepper-text">
+              <span class="label">
+                <AppIcon :name="s.icon" size="inline" color="accent" class="step-icon" />
+                {{ s.label }}
+              </span>
+              <span class="hint">{{ stepCopy[s.key].short }}</span>
+            </span>
+          </button>
+        </li>
+      </ol>
+    </aside>
+
+    <section class="wizard-main">
+      <div class="progress" role="progressbar" :aria-valuenow="progress" aria-valuemin="0" aria-valuemax="100">
+        <div class="progress-bar" :style="{ width: progress + '%' }" />
       </div>
 
       <Transition
@@ -80,7 +164,7 @@ const atLast = computed(() => current.value === steps.value.length - 1)
         :leave-to-class="fadeSlideUp.leaveToClass"
         mode="out-in"
       >
-        <div :key="steps[current].key">
+        <div :key="steps[current].key" class="step-container">
           <template v-if="steps[current].key==='tier'">
             <TierSelectionStep
               :sbType="props.sbType"
@@ -110,18 +194,278 @@ const atLast = computed(() => current.value === steps.value.length - 1)
             <EnvironmentFeaturesForm v-else :environment="props.environment" :tier="props.tier" />
           </template>
           <template v-else>
-            <div class="text-[color:var(--muted)]">
-              Use the preview panel to the right to review and sanity-check your build. Export options and printable output live in the top toolbar.
+            <div class="review-hint">
+              <h4>Review everything in the preview</h4>
+              <p>
+                The preview card outside of this modal updates in real time. Export, print, or copy to markdown once the
+                statblock feels right.
+              </p>
             </div>
           </template>
         </div>
       </Transition>
 
-      <div class="mt-4 flex items-center justify-between">
-        <AppButton variant="outline" size="sm" :disabled="atFirst" @click="back">Back</AppButton>
-        <AppButton variant="primary" size="sm" @click="next">{{ atLast ? 'Finish' : 'Next' }}</AppButton>
-      </div>
-    </AppCard>
+      <footer class="wizard-nav">
+        <AppButton variant="subtle" size="sm" :disabled="atFirst" @click="back">Back</AppButton>
+        <div class="nav-meta">Step {{ current + 1 }} of {{ steps.length }}</div>
+        <AppButton variant="primary" size="sm" @click="next">{{ atLast ? 'Finish' : 'Next step' }}</AppButton>
+      </footer>
+    </section>
   </div>
 </template>
 
+<style scoped>
+.wizard-shell {
+  display: flex;
+  flex-direction: row;
+  gap: 1.5rem;
+  height: 100%;
+  min-height: 0;
+}
+
+.wizard-sidebar {
+  width: min(260px, 28%);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  border-right: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  padding-right: 1.25rem;
+}
+
+.sidebar-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.step-count {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+}
+
+.sidebar-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.sidebar-detail {
+  margin: 0;
+  color: color-mix(in srgb, var(--muted) 86%, transparent);
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.stepper {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.stepper-item {
+  width: 100%;
+  border: none;
+  background: transparent;
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.6rem 0.5rem;
+  border-radius: var(--radius-md);
+  transition: background 0.15s ease, transform 0.15s ease;
+  text-align: left;
+  cursor: pointer;
+}
+
+.stepper-item:hover {
+  background: color-mix(in srgb, var(--surface-veil) 80%, transparent);
+}
+
+.stepper-item.active {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  transform: translateX(2px);
+}
+
+.stepper-item.active .indicator {
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  background: color-mix(in srgb, var(--accent) 26%, transparent);
+  color: color-mix(in srgb, var(--bg) 90%, transparent);
+}
+
+.stepper-item.complete .indicator {
+  background: color-mix(in srgb, var(--accent) 85%, transparent);
+}
+
+.stepper-item.complete .indicator span {
+  color: color-mix(in srgb, var(--bg) 100%, transparent);
+}
+
+.indicator {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--btn-border) 70%, transparent);
+  background: color-mix(in srgb, var(--surface-veil) 70%, transparent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--fg) 90%, transparent);
+}
+
+.stepper-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.stepper-text .label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.stepper-text .hint {
+  font-size: 0.75rem;
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+}
+
+.step-icon {
+  flex-shrink: 0;
+}
+
+.checkmark {
+  font-weight: 700;
+  color: color-mix(in srgb, var(--bg) 100%, transparent);
+  font-size: 0.85rem;
+}
+
+.wizard-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 0;
+}
+
+.progress {
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-veil) 70%, transparent);
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--accent) 60%, transparent);
+  transition: width 0.2s ease;
+}
+
+.step-container {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.step-container :deep(.app-card) {
+  background: color-mix(in srgb, var(--surface-veil) 88%, transparent);
+}
+
+.review-hint {
+  border: 1px dashed color-mix(in srgb, var(--border) 65%, transparent);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  background: color-mix(in srgb, var(--surface-veil) 70%, transparent);
+}
+
+.review-hint h4 {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+}
+
+.review-hint p {
+  margin: 0;
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
+  font-size: 0.88rem;
+}
+
+.wizard-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  padding-top: 1rem;
+}
+
+.nav-meta {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--muted) 80%, transparent);
+}
+
+@media (max-width: 960px) {
+  .wizard-shell {
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .wizard-sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+    padding-right: 0;
+    padding-bottom: 1rem;
+  }
+
+  .stepper {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .stepper-item {
+    width: calc(50% - 0.25rem);
+  }
+
+  .wizard-main {
+    padding-bottom: 0.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .stepper-item {
+    width: 100%;
+  }
+
+  .wizard-nav {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .wizard-nav > * {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .nav-meta {
+    order: -1;
+    text-align: center;
+  }
+}
+</style>

--- a/apps/daggerheart-statblock-builder/src/style.css
+++ b/apps/daggerheart-statblock-builder/src/style.css
@@ -1,7 +1,9 @@
 @import "tailwindcss";
 @import "@my-monorepo/theme/styles.css";
 
-html, body, #app { height: 100%; }
+html, body, #app {
+  height: 100%;
+}
 
 body {
   margin: 0;
@@ -10,54 +12,32 @@ body {
   color: var(--fg);
 }
 
-a { color: var(--link); }
+a {
+  color: var(--link);
+}
 
-a:hover { text-decoration: none; }
-
-header.header { margin-bottom: 0.75rem; }
+a:hover {
+  text-decoration: none;
+}
 
 .toolbar {
   position: sticky;
-  top: 0;
-  z-index: 30;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--surface-translucent) 94%, transparent);
-  box-shadow: var(--shadow-soft);
-  backdrop-filter: blur(12px);
-}
-
-.toolbar.topbar { border-radius: var(--radius-sm); }
-
-.layout {
-  display: grid;
-  gap: 1.25rem;
-  align-items: start;
-}
-
-@media (min-width: 1024px) {
-  .layout { grid-template-columns: 2fr 1fr; }
-}
-
-.row {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.card {
-  border: 1px solid var(--border);
-  padding: 1.25rem;
-  border-radius: var(--radius-lg);
-  background: var(--surface-panel);
+  top: 1rem;
+  z-index: 25;
+  border-radius: var(--radius-xl);
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  background: color-mix(in srgb, var(--surface-translucent) 90%, transparent);
   box-shadow: var(--shadow-card);
-  backdrop-filter: blur(18px);
+  backdrop-filter: blur(16px);
 }
 
-.editor-col > * + * { margin-top: 0.85rem; }
-.editor-root > * { min-width: 0; }
+.toolbar.topbar {
+  margin-top: -1.5rem;
+}
 
-.preview-col { position: sticky; top: 84px; }
+.print-only {
+  display: none;
+}
 
 .statblock {
   border-left: 6px solid var(--accent);
@@ -67,8 +47,14 @@ header.header { margin-bottom: 0.75rem; }
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
-.statblock.enemy { --accent: var(--enemy-accent); }
-.statblock.environment { --accent: var(--env-accent); }
+.statblock.enemy {
+  --accent: var(--enemy-accent);
+}
+
+.statblock.environment {
+  --accent: var(--env-accent);
+}
+
 .statblock h3 {
   color: var(--accent);
   text-transform: uppercase;
@@ -76,8 +62,7 @@ header.header { margin-bottom: 0.75rem; }
 }
 
 @media print {
-  .toolbar,
-  .layout > :not(.print-only) {
+  .toolbar {
     display: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the statblock builder landing view with a glassmorphism hero, quick summary cards, and improved toolbar styling
- convert the editor experience into a modal-based wizard with a guided stepper, progress indicator, and finish handler
- modernize the live preview card with richer meta chips, structured sections, and friendlier empty state messaging

## Testing
- pnpm --filter daggerheart-statblock-builder build

------
https://chatgpt.com/codex/tasks/task_e_68d64fa95310832fb326a860a1f775b3