### PR TITLE
Refactor UI theme to Material 3 tokens and expand motion presets

### DIFF
--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,142 +1,240 @@
 export const fonts = {
-  sans: "'Space Grotesk', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif",
-  mono: "'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Source Code Pro', monospace",
-  wide: "'Space Grotesk', 'Orbitron', 'Inter', sans-serif"
+  sans: "'Roboto Flex', 'Noto Sans', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif",
+  mono: "'Roboto Mono', 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Source Code Pro', monospace",
+  display: "'Google Sans Display', 'Roboto Flex', 'Segoe UI', system-ui, sans-serif"
 } as const
 
 export const radii = {
-  xs: '0.35rem',
-  sm: '0.65rem',
-  md: '0.9rem',
-  lg: '1.25rem',
-  xl: '1.75rem',
+  xs: '0.25rem',
+  sm: '0.5rem',
+  md: '0.75rem',
+  lg: '1rem',
+  xl: '1.5rem',
   pill: '999px'
 } as const
 
 export const transitions = {
-  fast: '140ms cubic-bezier(0.2, 0.8, 0.2, 1)',
-  base: '220ms cubic-bezier(0.2, 0.8, 0.2, 1)',
-  spring: '260ms cubic-bezier(0.16, 0.84, 0.44, 1)'
+  micro: '120ms cubic-bezier(0.2, 0, 0, 1)',
+  short: '160ms cubic-bezier(0.2, 0, 0, 1)',
+  medium: '220ms cubic-bezier(0.2, 0, 0, 1)',
+  long: '320ms cubic-bezier(0.2, 0, 0, 1)',
+  emphasized: '220ms cubic-bezier(0.05, 0.7, 0.1, 1)'
 } as const
 
 export const shadows = {
-  button: '0 12px 30px -22px rgba(34, 211, 238, 0.8), inset 0 0 0 1px rgba(255,255,255,0.04)',
-  buttonHover: '0 18px 40px -22px rgba(244, 114, 208, 0.75), inset 0 0 0 1px rgba(255,255,255,0.06)',
-  card: '0 30px 80px -50px rgba(16, 20, 60, 0.95), 0 0 0 1px rgba(34, 211, 238, 0.18)',
-  elevated: '0 24px 70px -35px rgba(12, 13, 40, 0.95), 0 0 0 1px rgba(56, 189, 248, 0.25)',
-  glow: '0 0 0 1px rgba(244, 114, 208, 0.4), 0 0 35px rgba(244, 114, 208, 0.22)'
+  level1: '0 1px 2px 0 rgba(15, 23, 42, 0.08), 0 1px 3px 1px rgba(15, 23, 42, 0.12)',
+  level2: '0 2px 6px 2px rgba(15, 23, 42, 0.08), 0 2px 4px -1px rgba(15, 23, 42, 0.12)',
+  level3: '0 6px 10px 4px rgba(15, 23, 42, 0.1), 0 2px 4px -1px rgba(15, 23, 42, 0.12)',
+  level4: '0 8px 12px 6px rgba(15, 23, 42, 0.12), 0 4px 6px -2px rgba(15, 23, 42, 0.16)',
+  level5: '0 12px 20px 8px rgba(15, 23, 42, 0.14), 0 6px 8px -4px rgba(15, 23, 42, 0.2)'
 } as const
 
-const cyberpunkVars = {
-  '--cp-color-bg': '#05060a',
-  '--cp-color-surface': '#0f1325',
-  '--cp-color-surface-2': '#171c38',
-  '--cp-color-border-soft': 'rgba(56, 189, 248, 0.24)',
-  '--cp-color-border-strong': 'rgba(244, 114, 208, 0.45)',
-  '--cp-color-border-muted': 'rgba(148, 163, 184, 0.2)',
-  '--cp-color-text': '#ecf2ff',
-  '--cp-color-text-muted': '#94a3b8',
-  '--cp-color-accent': '#f472d0',
-  '--cp-color-accent-weak': 'rgba(244, 114, 208, 0.16)',
-  '--cp-color-accent-strong': '#22d3ee',
-  '--cp-color-positive': '#4ade80',
-  '--cp-color-warning': '#facc15',
-  '--cp-color-danger': '#fb7185',
-  '--cp-color-link': '#38bdf8',
-  '--cp-button-bg': 'rgba(15, 23, 42, 0.72)',
-  '--cp-button-fg': '#f8fafc',
-  '--cp-button-border': 'rgba(148, 163, 184, 0.32)',
-  '--cp-button-border-strong': 'rgba(244, 114, 208, 0.45)',
-  '--cp-surface-translucent': 'color-mix(in srgb, #0f1325 92%, transparent)',
-  '--cp-surface-veil': 'color-mix(in srgb, #171c38 78%, transparent)',
-  '--cp-surface-panel': 'color-mix(in srgb, #171c38 65%, transparent)',
-  '--cp-overlay': 'rgba(5, 6, 10, 0.55)',
-  '--cp-gradient-bg': 'radial-gradient(120% 120% at 0% 0%, rgba(244, 114, 208, 0.14) 0%, transparent 58%), radial-gradient(120% 120% at 100% 0%, rgba(34, 211, 238, 0.12) 0%, transparent 60%), radial-gradient(180% 150% at 50% 100%, rgba(15, 23, 42, 0.85) 0%, rgba(5, 6, 10, 0.95) 100%)'
+const materialIndigoVars = {
+  '--md-sys-color-primary': '#6750A4',
+  '--md-sys-color-on-primary': '#FFFFFF',
+  '--md-sys-color-primary-container': '#EADDFF',
+  '--md-sys-color-on-primary-container': '#21005D',
+  '--md-sys-color-secondary': '#625B71',
+  '--md-sys-color-on-secondary': '#FFFFFF',
+  '--md-sys-color-secondary-container': '#E8DEF8',
+  '--md-sys-color-on-secondary-container': '#1D192B',
+  '--md-sys-color-tertiary': '#7D5260',
+  '--md-sys-color-on-tertiary': '#FFFFFF',
+  '--md-sys-color-tertiary-container': '#FFD8E4',
+  '--md-sys-color-on-tertiary-container': '#31111D',
+  '--md-sys-color-background': '#FFFBFE',
+  '--md-sys-color-on-background': '#1C1B1F',
+  '--md-sys-color-surface': '#FFFBFE',
+  '--md-sys-color-on-surface': '#1C1B1F',
+  '--md-sys-color-surface-variant': '#E7E0EC',
+  '--md-sys-color-on-surface-variant': '#49454F',
+  '--md-sys-color-outline': '#79747E',
+  '--md-sys-color-outline-variant': '#CAC4D0',
+  '--md-sys-color-shadow': '#000000',
+  '--md-sys-color-scrim': '#000000',
+  '--md-sys-color-surface-tint': '#6750A4',
+  '--md-sys-color-inverse-surface': '#313033',
+  '--md-sys-color-inverse-on-surface': '#F4EFF4',
+  '--md-sys-color-inverse-primary': '#D0BCFF',
+  '--md-sys-color-surface-container-lowest': '#FFFFFF',
+  '--md-sys-color-surface-container-low': '#F7F2FA',
+  '--md-sys-color-surface-container': '#F3EDF7',
+  '--md-sys-color-surface-container-high': '#ECE6F0',
+  '--md-sys-color-surface-container-highest': '#E6E0E9',
+  '--md-sys-color-error': '#B3261E',
+  '--md-sys-color-on-error': '#FFFFFF',
+  '--md-sys-color-error-container': '#F9DEDC',
+  '--md-sys-color-on-error-container': '#410E0B',
+  '--md-sys-color-success': '#2E7D32',
+  '--md-sys-color-on-success': '#FFFFFF',
+  '--md-sys-color-success-container': '#C8E6C9',
+  '--md-sys-color-on-success-container': '#0F3813',
+  '--md-comp-button-filled-container': 'var(--md-sys-color-primary)',
+  '--md-comp-button-filled-on-container': 'var(--md-sys-color-on-primary)',
+  '--md-comp-button-tonal-container': 'var(--md-sys-color-secondary-container)',
+  '--md-comp-button-tonal-on-container': 'var(--md-sys-color-on-secondary-container)',
+  '--md-comp-button-elevated-container': 'var(--md-sys-color-surface-container-high)',
+  '--md-comp-button-elevated-on-container': 'var(--md-sys-color-on-surface)',
+  '--md-comp-button-outlined-outline': 'var(--md-sys-color-outline)',
+  '--md-comp-button-text-label': 'var(--md-sys-color-primary)',
+  '--md-comp-button-ghost-label': 'var(--md-sys-color-on-surface-variant)',
+  '--md-comp-button-danger-container': 'var(--md-sys-color-error)',
+  '--md-comp-button-danger-on-container': 'var(--md-sys-color-on-error)',
+  '--md-comp-button-success-container': 'var(--md-sys-color-success)',
+  '--md-comp-button-success-on-container': 'var(--md-sys-color-on-success)',
+  '--md-comp-focus-ring': 'var(--md-sys-color-primary)',
+  '--md-comp-state-layer-opacity-hover': '0.08',
+  '--md-comp-state-layer-opacity-focus': '0.12',
+  '--md-comp-state-layer-opacity-pressed': '0.12'
 } as const
 
-const neonNoirVars = {
-  '--cp-color-bg': '#04050f',
-  '--cp-color-surface': '#0e1324',
-  '--cp-color-surface-2': '#161b33',
-  '--cp-color-border-soft': 'rgba(96, 165, 250, 0.28)',
-  '--cp-color-border-strong': 'rgba(56, 189, 248, 0.48)',
-  '--cp-color-border-muted': 'rgba(79, 70, 229, 0.2)',
-  '--cp-color-text': '#dfe7ff',
-  '--cp-color-text-muted': '#9ca3c7',
-  '--cp-color-accent': '#818cf8',
-  '--cp-color-accent-weak': 'rgba(129, 140, 248, 0.18)',
-  '--cp-color-accent-strong': '#38bdf8',
-  '--cp-color-positive': '#34d399',
-  '--cp-color-warning': '#fbbf24',
-  '--cp-color-danger': '#f87171',
-  '--cp-color-link': '#60a5fa',
-  '--cp-button-bg': 'rgba(12, 19, 44, 0.78)',
-  '--cp-button-fg': '#f5f7ff',
-  '--cp-button-border': 'rgba(129, 140, 248, 0.32)',
-  '--cp-button-border-strong': 'rgba(56, 189, 248, 0.45)',
-  '--cp-surface-translucent': 'color-mix(in srgb, #0e1324 90%, transparent)',
-  '--cp-surface-veil': 'color-mix(in srgb, #161b33 74%, transparent)',
-  '--cp-surface-panel': 'color-mix(in srgb, #161b33 62%, transparent)',
-  '--cp-overlay': 'rgba(4, 7, 17, 0.6)',
-  '--cp-gradient-bg': 'radial-gradient(140% 120% at 0% 0%, rgba(129, 140, 248, 0.16) 0%, transparent 55%), radial-gradient(120% 120% at 100% 0%, rgba(56, 189, 248, 0.12) 0%, transparent 60%), radial-gradient(160% 140% at 50% 100%, rgba(8, 11, 26, 0.9) 0%, rgba(4, 5, 15, 0.96) 100%)'
+const materialEmeraldVars = {
+  '--md-sys-color-primary': '#256F3A',
+  '--md-sys-color-on-primary': '#FFFFFF',
+  '--md-sys-color-primary-container': '#A4F2B7',
+  '--md-sys-color-on-primary-container': '#00210C',
+  '--md-sys-color-secondary': '#4F6354',
+  '--md-sys-color-on-secondary': '#FFFFFF',
+  '--md-sys-color-secondary-container': '#D1E8D4',
+  '--md-sys-color-on-secondary-container': '#0D1F13',
+  '--md-sys-color-tertiary': '#3A6473',
+  '--md-sys-color-on-tertiary': '#FFFFFF',
+  '--md-sys-color-tertiary-container': '#BEEAF4',
+  '--md-sys-color-on-tertiary-container': '#001F27',
+  '--md-sys-color-background': '#F6FFF4',
+  '--md-sys-color-on-background': '#191C19',
+  '--md-sys-color-surface': '#F6FFF4',
+  '--md-sys-color-on-surface': '#191C19',
+  '--md-sys-color-surface-variant': '#DBE5D8',
+  '--md-sys-color-on-surface-variant': '#3F4A40',
+  '--md-sys-color-outline': '#70796E',
+  '--md-sys-color-outline-variant': '#C0C9BC',
+  '--md-sys-color-shadow': '#000000',
+  '--md-sys-color-scrim': '#000000',
+  '--md-sys-color-surface-tint': '#256F3A',
+  '--md-sys-color-inverse-surface': '#2D312D',
+  '--md-sys-color-inverse-on-surface': '#F0F2EE',
+  '--md-sys-color-inverse-primary': '#8DD69D',
+  '--md-sys-color-surface-container-lowest': '#FFFFFF',
+  '--md-sys-color-surface-container-low': '#EBF6EA',
+  '--md-sys-color-surface-container': '#E1ECE0',
+  '--md-sys-color-surface-container-high': '#D6E1D5',
+  '--md-sys-color-surface-container-highest': '#CBD6CB',
+  '--md-sys-color-error': '#BA1A1A',
+  '--md-sys-color-on-error': '#FFFFFF',
+  '--md-sys-color-error-container': '#FFDAD6',
+  '--md-sys-color-on-error-container': '#410002',
+  '--md-sys-color-success': '#2E7D32',
+  '--md-sys-color-on-success': '#FFFFFF',
+  '--md-sys-color-success-container': '#C8E6C9',
+  '--md-sys-color-on-success-container': '#0F3813',
+  '--md-comp-button-filled-container': 'var(--md-sys-color-primary)',
+  '--md-comp-button-filled-on-container': 'var(--md-sys-color-on-primary)',
+  '--md-comp-button-tonal-container': 'var(--md-sys-color-secondary-container)',
+  '--md-comp-button-tonal-on-container': 'var(--md-sys-color-on-secondary-container)',
+  '--md-comp-button-elevated-container': 'var(--md-sys-color-surface-container-high)',
+  '--md-comp-button-elevated-on-container': 'var(--md-sys-color-on-surface)',
+  '--md-comp-button-outlined-outline': 'var(--md-sys-color-outline)',
+  '--md-comp-button-text-label': 'var(--md-sys-color-primary)',
+  '--md-comp-button-ghost-label': 'var(--md-sys-color-on-surface-variant)',
+  '--md-comp-button-danger-container': 'var(--md-sys-color-error)',
+  '--md-comp-button-danger-on-container': 'var(--md-sys-color-on-error)',
+  '--md-comp-button-success-container': 'var(--md-sys-color-success)',
+  '--md-comp-button-success-on-container': 'var(--md-sys-color-on-success)',
+  '--md-comp-focus-ring': 'var(--md-sys-color-primary)',
+  '--md-comp-state-layer-opacity-hover': '0.08',
+  '--md-comp-state-layer-opacity-focus': '0.12',
+  '--md-comp-state-layer-opacity-pressed': '0.12'
 } as const
 
-const synthwaveDawnVars = {
-  '--cp-color-bg': '#14040f',
-  '--cp-color-surface': '#1d0821',
-  '--cp-color-surface-2': '#2a1033',
-  '--cp-color-border-soft': 'rgba(249, 115, 22, 0.28)',
-  '--cp-color-border-strong': 'rgba(236, 72, 153, 0.45)',
-  '--cp-color-border-muted': 'rgba(253, 186, 116, 0.2)',
-  '--cp-color-text': '#ffeefc',
-  '--cp-color-text-muted': '#f9a8d4',
-  '--cp-color-accent': '#ec4899',
-  '--cp-color-accent-weak': 'rgba(236, 72, 153, 0.2)',
-  '--cp-color-accent-strong': '#facc15',
-  '--cp-color-positive': '#4ade80',
-  '--cp-color-warning': '#fbbf24',
-  '--cp-color-danger': '#fb7185',
-  '--cp-color-link': '#f472b6',
-  '--cp-button-bg': 'rgba(45, 14, 62, 0.78)',
-  '--cp-button-fg': '#fff5fb',
-  '--cp-button-border': 'rgba(236, 72, 153, 0.35)',
-  '--cp-button-border-strong': 'rgba(250, 204, 21, 0.4)',
-  '--cp-surface-translucent': 'color-mix(in srgb, #1d0821 92%, transparent)',
-  '--cp-surface-veil': 'color-mix(in srgb, #2a1033 74%, transparent)',
-  '--cp-surface-panel': 'color-mix(in srgb, #2a1033 64%, transparent)',
-  '--cp-overlay': 'rgba(17, 6, 24, 0.62)',
-  '--cp-gradient-bg': 'radial-gradient(130% 140% at 0% 0%, rgba(236, 72, 153, 0.18) 0%, transparent 60%), radial-gradient(140% 120% at 100% 0%, rgba(250, 204, 21, 0.12) 0%, transparent 60%), radial-gradient(160% 150% at 50% 100%, rgba(30, 8, 45, 0.92) 0%, rgba(14, 4, 19, 0.96) 100%)'
+const materialMidnightVars = {
+  '--md-sys-color-primary': '#D0BCFF',
+  '--md-sys-color-on-primary': '#381E72',
+  '--md-sys-color-primary-container': '#4F378B',
+  '--md-sys-color-on-primary-container': '#EADDFF',
+  '--md-sys-color-secondary': '#CCC2DC',
+  '--md-sys-color-on-secondary': '#332D41',
+  '--md-sys-color-secondary-container': '#4A4458',
+  '--md-sys-color-on-secondary-container': '#E8DEF8',
+  '--md-sys-color-tertiary': '#EFB8C8',
+  '--md-sys-color-on-tertiary': '#492532',
+  '--md-sys-color-tertiary-container': '#633B48',
+  '--md-sys-color-on-tertiary-container': '#FFD8E4',
+  '--md-sys-color-background': '#1C1B1F',
+  '--md-sys-color-on-background': '#E6E1E5',
+  '--md-sys-color-surface': '#1C1B1F',
+  '--md-sys-color-on-surface': '#E6E1E5',
+  '--md-sys-color-surface-variant': '#49454F',
+  '--md-sys-color-on-surface-variant': '#CAC4D0',
+  '--md-sys-color-outline': '#938F99',
+  '--md-sys-color-outline-variant': '#49454F',
+  '--md-sys-color-shadow': '#000000',
+  '--md-sys-color-scrim': '#000000',
+  '--md-sys-color-surface-tint': '#D0BCFF',
+  '--md-sys-color-inverse-surface': '#E6E1E5',
+  '--md-sys-color-inverse-on-surface': '#313033',
+  '--md-sys-color-inverse-primary': '#6750A4',
+  '--md-sys-color-surface-container-lowest': '#0F0D13',
+  '--md-sys-color-surface-container-low': '#1D1B20',
+  '--md-sys-color-surface-container': '#211F26',
+  '--md-sys-color-surface-container-high': '#2B2930',
+  '--md-sys-color-surface-container-highest': '#36343B',
+  '--md-sys-color-error': '#F2B8B5',
+  '--md-sys-color-on-error': '#601410',
+  '--md-sys-color-error-container': '#8C1D18',
+  '--md-sys-color-on-error-container': '#F9DEDC',
+  '--md-sys-color-success': '#8EDFA5',
+  '--md-sys-color-on-success': '#003915',
+  '--md-sys-color-success-container': '#135727',
+  '--md-sys-color-on-success-container': '#BEECC6',
+  '--md-comp-button-filled-container': 'var(--md-sys-color-primary)',
+  '--md-comp-button-filled-on-container': 'var(--md-sys-color-on-primary)',
+  '--md-comp-button-tonal-container': 'var(--md-sys-color-secondary-container)',
+  '--md-comp-button-tonal-on-container': 'var(--md-sys-color-on-secondary-container)',
+  '--md-comp-button-elevated-container': 'var(--md-sys-color-surface-container-high)',
+  '--md-comp-button-elevated-on-container': 'var(--md-sys-color-on-surface)',
+  '--md-comp-button-outlined-outline': 'var(--md-sys-color-outline)',
+  '--md-comp-button-text-label': 'var(--md-sys-color-primary)',
+  '--md-comp-button-ghost-label': 'var(--md-sys-color-on-surface-variant)',
+  '--md-comp-button-danger-container': 'var(--md-sys-color-error)',
+  '--md-comp-button-danger-on-container': 'var(--md-sys-color-on-error)',
+  '--md-comp-button-success-container': 'var(--md-sys-color-success)',
+  '--md-comp-button-success-on-container': 'var(--md-sys-color-on-success)',
+  '--md-comp-focus-ring': 'var(--md-sys-color-primary)',
+  '--md-comp-state-layer-opacity-hover': '0.08',
+  '--md-comp-state-layer-opacity-focus': '0.12',
+  '--md-comp-state-layer-opacity-pressed': '0.16'
 } as const
 
 export const themeVariables = {
-  'cyberpunk': cyberpunkVars,
-  'neon-noir': neonNoirVars,
-  'synthwave-dawn': synthwaveDawnVars
+  'material-indigo': materialIndigoVars,
+  'material-emerald': materialEmeraldVars,
+  'material-midnight': materialMidnightVars
 } as const
 
 export type ThemeName = keyof typeof themeVariables
 export type ThemeVariables = typeof themeVariables[ThemeName]
 export type ThemeVariableName = keyof ThemeVariables
 
-export const themeOrder: ThemeName[] = ['cyberpunk', 'neon-noir', 'synthwave-dawn']
+export const themeOrder: ThemeName[] = ['material-indigo', 'material-emerald', 'material-midnight']
 
-export const defaultThemeName: ThemeName = 'cyberpunk'
+export const defaultThemeName: ThemeName = 'material-indigo'
 
 export const themeMeta: Record<ThemeName, { label: string; description: string; accent: string }> = {
-  'cyberpunk': {
-    label: 'Cyberpunk Pulse',
-    description: 'Electric magenta and cyan pulses with deep midnight surfaces.',
-    accent: '#f472d0'
+  'material-indigo': {
+    label: 'Material Indigo',
+    description: 'Warm purple primaries and soft neutrals inspired by Material 3 defaults.',
+    accent: '#6750A4'
   },
-  'neon-noir': {
-    label: 'Neon Noir',
-    description: 'Moody indigo base with luminous periwinkle and cyan edges.',
-    accent: '#818cf8'
+  'material-emerald': {
+    label: 'Material Emerald',
+    description: 'Fresh botanical greens with airy surfaces and calming contrasts.',
+    accent: '#256F3A'
   },
-  'synthwave-dawn': {
-    label: 'Synthwave Dawn',
-    description: 'Sunrise magentas and amber glows inspired by 80s album art.',
-    accent: '#ec4899'
+  'material-midnight': {
+    label: 'Material Midnight',
+    description: 'Moody dark surfaces with luminous lilac and blush highlights.',
+    accent: '#D0BCFF'
   }
 }
 
@@ -144,4 +242,4 @@ export function isThemeName(value: string): value is ThemeName {
   return themeOrder.includes(value as ThemeName)
 }
 
-export const themeVariablesList: ThemeVariableName[] = Object.keys(cyberpunkVars) as ThemeVariableName[]
+export const themeVariablesList: ThemeVariableName[] = Object.keys(materialIndigoVars) as ThemeVariableName[]

--- a/packages/theme/src/index.css
+++ b/packages/theme/src/index.css
@@ -1,165 +1,141 @@
 :root,
-:root[data-theme='cyberpunk'] {
-  color-scheme: dark;
+:root[data-theme='material-indigo'] {
+  color-scheme: light;
   font-family: var(--font-sans);
-  --font-sans: 'Space Grotesk', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Source Code Pro', monospace;
-  --font-wide: 'Space Grotesk', 'Orbitron', 'Inter', sans-serif;
 
-  --radius-xs: 0.35rem;
-  --radius-sm: 0.65rem;
-  --radius-md: 0.9rem;
-  --radius-lg: 1.25rem;
-  --radius-xl: 1.75rem;
+  --font-sans: 'Roboto Flex', 'Noto Sans', 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-display: 'Google Sans Display', 'Roboto Flex', 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'Roboto Mono', 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', 'Source Code Pro', monospace;
+
+  --radius-xs: 0.25rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.5rem;
   --radius-pill: 999px;
 
-  --shadow-button: 0 12px 30px -22px rgba(34, 211, 238, 0.8), inset 0 0 0 1px rgba(255,255,255,0.04);
-  --shadow-button-hover: 0 18px 40px -22px rgba(244, 114, 208, 0.75), inset 0 0 0 1px rgba(255,255,255,0.06);
-  --shadow-card: 0 30px 80px -50px rgba(16, 20, 60, 0.95), 0 0 0 1px rgba(34, 211, 238, 0.18);
-  --shadow-elevated: 0 24px 70px -35px rgba(12, 13, 40, 0.95), 0 0 0 1px rgba(56, 189, 248, 0.25);
-  --shadow-soft: 0 18px 60px -40px rgba(34, 211, 238, 0.5);
-  --shadow-glow: 0 0 0 1px rgba(244, 114, 208, 0.4), 0 0 35px rgba(244, 114, 208, 0.22);
+  --shadow-level1: 0 1px 2px 0 rgba(15, 23, 42, 0.08), 0 1px 3px 1px rgba(15, 23, 42, 0.12);
+  --shadow-level2: 0 2px 6px 2px rgba(15, 23, 42, 0.08), 0 2px 4px -1px rgba(15, 23, 42, 0.12);
+  --shadow-level3: 0 6px 10px 4px rgba(15, 23, 42, 0.1), 0 2px 4px -1px rgba(15, 23, 42, 0.12);
+  --shadow-level4: 0 8px 12px 6px rgba(15, 23, 42, 0.12), 0 4px 6px -2px rgba(15, 23, 42, 0.16);
+  --shadow-level5: 0 12px 20px 8px rgba(15, 23, 42, 0.14), 0 6px 8px -4px rgba(15, 23, 42, 0.2);
 
-  --transition-fast: 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
-  --transition-base: 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
-  --transition-spring: 260ms cubic-bezier(0.16, 0.84, 0.44, 1);
+  --transition-micro: 120ms cubic-bezier(0.2, 0, 0, 1);
+  --transition-short: 160ms cubic-bezier(0.2, 0, 0, 1);
+  --transition-medium: 220ms cubic-bezier(0.2, 0, 0, 1);
+  --transition-long: 320ms cubic-bezier(0.2, 0, 0, 1);
+  --transition-emphasized: 220ms cubic-bezier(0.05, 0.7, 0.1, 1);
 
-  --cp-color-bg: #05060a;
-  --cp-color-surface: #0f1325;
-  --cp-color-surface-2: #171c38;
-  --cp-color-border-soft: rgba(56, 189, 248, 0.24);
-  --cp-color-border-strong: rgba(244, 114, 208, 0.45);
-  --cp-color-border-muted: rgba(148, 163, 184, 0.2);
-  --cp-color-text: #ecf2ff;
-  --cp-color-text-muted: #94a3b8;
-  --cp-color-accent: #f472d0;
-  --cp-color-accent-weak: rgba(244, 114, 208, 0.16);
-  --cp-color-accent-strong: #22d3ee;
-  --cp-color-positive: #4ade80;
-  --cp-color-warning: #facc15;
-  --cp-color-danger: #fb7185;
-  --cp-color-link: #38bdf8;
-  --cp-button-bg: rgba(15, 23, 42, 0.72);
-  --cp-button-fg: #f8fafc;
-  --cp-button-border: rgba(148, 163, 184, 0.32);
-  --cp-button-border-strong: rgba(244, 114, 208, 0.45);
-  --cp-surface-translucent: color-mix(in srgb, #0f1325 92%, transparent);
-  --cp-surface-veil: color-mix(in srgb, #171c38 78%, transparent);
-  --cp-surface-panel: color-mix(in srgb, #171c38 65%, transparent);
-  --cp-overlay: rgba(5, 6, 10, 0.55);
-  --cp-gradient-bg: radial-gradient(120% 120% at 0% 0%, rgba(244, 114, 208, 0.14) 0%, transparent 58%), radial-gradient(120% 120% at 100% 0%, rgba(34, 211, 238, 0.12) 0%, transparent 60%), radial-gradient(180% 150% at 50% 100%, rgba(15, 23, 42, 0.85) 0%, rgba(5, 6, 10, 0.95) 100%);
+  /* Default theme values mirror material-indigo for SSR */
+  --md-sys-color-primary: #6750A4;
+  --md-sys-color-on-primary: #FFFFFF;
+  --md-sys-color-primary-container: #EADDFF;
+  --md-sys-color-on-primary-container: #21005D;
+  --md-sys-color-secondary: #625B71;
+  --md-sys-color-on-secondary: #FFFFFF;
+  --md-sys-color-secondary-container: #E8DEF8;
+  --md-sys-color-on-secondary-container: #1D192B;
+  --md-sys-color-tertiary: #7D5260;
+  --md-sys-color-on-tertiary: #FFFFFF;
+  --md-sys-color-tertiary-container: #FFD8E4;
+  --md-sys-color-on-tertiary-container: #31111D;
+  --md-sys-color-background: #FFFBFE;
+  --md-sys-color-on-background: #1C1B1F;
+  --md-sys-color-surface: #FFFBFE;
+  --md-sys-color-on-surface: #1C1B1F;
+  --md-sys-color-surface-variant: #E7E0EC;
+  --md-sys-color-on-surface-variant: #49454F;
+  --md-sys-color-outline: #79747E;
+  --md-sys-color-outline-variant: #CAC4D0;
+  --md-sys-color-shadow: #000000;
+  --md-sys-color-scrim: #000000;
+  --md-sys-color-surface-tint: #6750A4;
+  --md-sys-color-inverse-surface: #313033;
+  --md-sys-color-inverse-on-surface: #F4EFF4;
+  --md-sys-color-inverse-primary: #D0BCFF;
+  --md-sys-color-surface-container-lowest: #FFFFFF;
+  --md-sys-color-surface-container-low: #F7F2FA;
+  --md-sys-color-surface-container: #F3EDF7;
+  --md-sys-color-surface-container-high: #ECE6F0;
+  --md-sys-color-surface-container-highest: #E6E0E9;
+  --md-sys-color-error: #B3261E;
+  --md-sys-color-on-error: #FFFFFF;
+  --md-sys-color-error-container: #F9DEDC;
+  --md-sys-color-on-error-container: #410E0B;
+  --md-sys-color-success: #2E7D32;
+  --md-sys-color-on-success: #FFFFFF;
+  --md-sys-color-success-container: #C8E6C9;
+  --md-sys-color-on-success-container: #0F3813;
 
-  --bg: var(--cp-color-bg);
-  --fg: var(--cp-color-text);
-  --muted: var(--cp-color-text-muted);
-  --surface: var(--cp-color-surface);
-  --surface-2: var(--cp-color-surface-2);
-  --surface-translucent: var(--cp-surface-translucent);
-  --surface-veil: var(--cp-surface-veil);
-  --surface-panel: var(--cp-surface-panel);
-  --border: var(--cp-color-border-soft);
-  --border-soft: var(--cp-color-border-soft);
-  --border-strong: var(--cp-color-border-strong);
-  --border-muted: var(--cp-color-border-muted);
-  --accent: var(--cp-color-accent);
-  --accent-weak: var(--cp-color-accent-weak);
-  --accent-strong: var(--cp-color-accent-strong);
-  --enemy-accent: var(--cp-color-danger);
-  --env-accent: var(--cp-color-positive);
-  --danger-soft: color-mix(in srgb, var(--enemy-accent) 16%, transparent);
-  --success-soft: color-mix(in srgb, var(--env-accent) 18%, transparent);
-  --danger-border: color-mix(in srgb, var(--enemy-accent) 45%, transparent);
-  --success-border: color-mix(in srgb, var(--env-accent) 45%, transparent);
-  --btn-bg: var(--cp-button-bg);
-  --btn-fg: var(--cp-button-fg);
-  --btn-border: var(--cp-button-border);
-  --btn-border-strong: var(--cp-button-border-strong);
-  --link: var(--cp-color-link);
-  --overlay: var(--cp-overlay);
-  --gridline: rgba(148, 163, 184, 0.08);
+  --md-comp-button-filled-container: var(--md-sys-color-primary);
+  --md-comp-button-filled-on-container: var(--md-sys-color-on-primary);
+  --md-comp-button-tonal-container: var(--md-sys-color-secondary-container);
+  --md-comp-button-tonal-on-container: var(--md-sys-color-on-secondary-container);
+  --md-comp-button-elevated-container: var(--md-sys-color-surface-container-high);
+  --md-comp-button-elevated-on-container: var(--md-sys-color-on-surface);
+  --md-comp-button-outlined-outline: var(--md-sys-color-outline);
+  --md-comp-button-text-label: var(--md-sys-color-primary);
+  --md-comp-button-ghost-label: var(--md-sys-color-on-surface-variant);
+  --md-comp-button-danger-container: var(--md-sys-color-error);
+  --md-comp-button-danger-on-container: var(--md-sys-color-on-error);
+  --md-comp-button-success-container: var(--md-sys-color-success);
+  --md-comp-button-success-on-container: var(--md-sys-color-on-success);
+  --md-comp-focus-ring: var(--md-sys-color-primary);
+  --md-comp-state-layer-opacity-hover: 0.08;
+  --md-comp-state-layer-opacity-focus: 0.12;
+  --md-comp-state-layer-opacity-pressed: 0.12;
+
+  --md-comp-button-filled-container-hover: color-mix(in srgb, var(--md-comp-button-filled-container) 92%, var(--md-sys-color-on-primary) 8%);
+  --md-comp-button-tonal-container-hover: color-mix(in srgb, var(--md-comp-button-tonal-container) 90%, var(--md-sys-color-on-secondary-container) 10%);
+  --md-comp-button-elevated-container-hover: color-mix(in srgb, var(--md-comp-button-elevated-container) 92%, var(--md-sys-color-surface-tint) 8%);
+  --md-comp-button-outlined-hover-layer: color-mix(in srgb, var(--md-comp-button-text-label) 12%, transparent);
+  --md-comp-button-text-hover-layer: color-mix(in srgb, var(--md-comp-button-text-label) 12%, transparent);
+  --md-comp-button-danger-container-hover: color-mix(in srgb, var(--md-comp-button-danger-container) 92%, var(--md-sys-color-on-error) 8%);
+  --md-comp-button-success-container-hover: color-mix(in srgb, var(--md-comp-button-success-container) 92%, var(--md-sys-color-on-success) 8%);
+  --md-comp-button-ghost-hover-layer: color-mix(in srgb, var(--md-comp-button-ghost-label) 10%, transparent);
+
+  --md-comp-field-container: color-mix(in srgb, var(--md-sys-color-surface) 88%, var(--md-sys-color-surface-variant) 12%);
+  --md-comp-field-outline: var(--md-sys-color-outline);
+  --md-comp-field-on-surface: var(--md-sys-color-on-surface);
+  --md-comp-field-placeholder: var(--md-sys-color-on-surface-variant);
+
+  /* Legacy aliases retained for downstream apps */
+  --bg: var(--md-sys-color-background);
+  --fg: var(--md-sys-color-on-surface);
+  --muted: var(--md-sys-color-on-surface-variant);
+  --surface: var(--md-sys-color-surface);
+  --surface-2: var(--md-sys-color-surface-container);
+  --surface-translucent: color-mix(in srgb, var(--md-sys-color-surface) 92%, transparent);
+  --surface-veil: color-mix(in srgb, var(--md-sys-color-surface) 82%, transparent);
+  --surface-panel: var(--md-sys-color-surface-container-high);
+  --border: var(--md-sys-color-outline-variant);
+  --border-soft: var(--md-sys-color-outline-variant);
+  --border-strong: var(--md-sys-color-outline);
+  --border-muted: color-mix(in srgb, var(--md-sys-color-outline) 40%, transparent);
+  --accent: var(--md-sys-color-primary);
+  --accent-weak: var(--md-sys-color-primary-container);
+  --accent-strong: var(--md-sys-color-on-primary);
+  --enemy-accent: var(--md-sys-color-error);
+  --env-accent: var(--md-sys-color-success);
+  --danger-soft: color-mix(in srgb, var(--enemy-accent) 14%, transparent);
+  --success-soft: color-mix(in srgb, var(--env-accent) 16%, transparent);
+  --danger-border: color-mix(in srgb, var(--enemy-accent) 30%, transparent);
+  --success-border: color-mix(in srgb, var(--env-accent) 30%, transparent);
+  --btn-bg: var(--md-comp-button-elevated-container);
+  --btn-fg: var(--md-comp-button-elevated-on-container);
+  --btn-border: var(--md-comp-button-outlined-outline);
+  --btn-border-strong: var(--md-comp-button-outlined-outline);
+  --link: var(--md-comp-button-text-label);
+  --overlay: color-mix(in srgb, var(--md-sys-color-scrim) 16%, transparent);
+  --gridline: color-mix(in srgb, var(--md-sys-color-outline) 6%, transparent);
 }
 
-[data-theme='neon-noir'] {
-  --cp-color-bg: #04050f;
-  --cp-color-surface: #0e1324;
-  --cp-color-surface-2: #161b33;
-  --cp-color-border-soft: rgba(96, 165, 250, 0.28);
-  --cp-color-border-strong: rgba(56, 189, 248, 0.48);
-  --cp-color-border-muted: rgba(79, 70, 229, 0.2);
-  --cp-color-text: #dfe7ff;
-  --cp-color-text-muted: #9ca3c7;
-  --cp-color-accent: #818cf8;
-  --cp-color-accent-weak: rgba(129, 140, 248, 0.18);
-  --cp-color-accent-strong: #38bdf8;
-  --cp-color-positive: #34d399;
-  --cp-color-warning: #fbbf24;
-  --cp-color-danger: #f87171;
-  --cp-color-link: #60a5fa;
-  --cp-button-bg: rgba(12, 19, 44, 0.78);
-  --cp-button-fg: #f5f7ff;
-  --cp-button-border: rgba(129, 140, 248, 0.32);
-  --cp-button-border-strong: rgba(56, 189, 248, 0.45);
-  --cp-surface-translucent: color-mix(in srgb, #0e1324 90%, transparent);
-  --cp-surface-veil: color-mix(in srgb, #161b33 74%, transparent);
-  --cp-surface-panel: color-mix(in srgb, #161b33 62%, transparent);
-  --cp-overlay: rgba(4, 7, 17, 0.6);
-  --cp-gradient-bg: radial-gradient(140% 120% at 0% 0%, rgba(129, 140, 248, 0.16) 0%, transparent 55%), radial-gradient(120% 120% at 100% 0%, rgba(56, 189, 248, 0.12) 0%, transparent 60%), radial-gradient(160% 140% at 50% 100%, rgba(8, 11, 26, 0.9) 0%, rgba(4, 5, 15, 0.96) 100%);
+[data-theme='material-emerald'] {
+  color-scheme: light;
 }
 
-[data-theme='synthwave-dawn'] {
-  --cp-color-bg: #14040f;
-  --cp-color-surface: #1d0821;
-  --cp-color-surface-2: #2a1033;
-  --cp-color-border-soft: rgba(249, 115, 22, 0.28);
-  --cp-color-border-strong: rgba(236, 72, 153, 0.45);
-  --cp-color-border-muted: rgba(253, 186, 116, 0.2);
-  --cp-color-text: #ffeefc;
-  --cp-color-text-muted: #f9a8d4;
-  --cp-color-accent: #ec4899;
-  --cp-color-accent-weak: rgba(236, 72, 153, 0.2);
-  --cp-color-accent-strong: #facc15;
-  --cp-color-positive: #4ade80;
-  --cp-color-warning: #fbbf24;
-  --cp-color-danger: #fb7185;
-  --cp-color-link: #f472b6;
-  --cp-button-bg: rgba(45, 14, 62, 0.78);
-  --cp-button-fg: #fff5fb;
-  --cp-button-border: rgba(236, 72, 153, 0.35);
-  --cp-button-border-strong: rgba(250, 204, 21, 0.4);
-  --cp-surface-translucent: color-mix(in srgb, #1d0821 92%, transparent);
-  --cp-surface-veil: color-mix(in srgb, #2a1033 74%, transparent);
-  --cp-surface-panel: color-mix(in srgb, #2a1033 64%, transparent);
-  --cp-overlay: rgba(17, 6, 24, 0.62);
-  --cp-gradient-bg: radial-gradient(130% 140% at 0% 0%, rgba(236, 72, 153, 0.18) 0%, transparent 60%), radial-gradient(140% 120% at 100% 0%, rgba(250, 204, 21, 0.12) 0%, transparent 60%), radial-gradient(160% 150% at 50% 100%, rgba(30, 8, 45, 0.92) 0%, rgba(14, 4, 19, 0.96) 100%);
-}
-
-@media (prefers-color-scheme: light) {
-  :root:not([data-theme]) {
-    --cp-color-bg: #14040f;
-    --cp-color-surface: #1d0821;
-    --cp-color-surface-2: #2a1033;
-    --cp-color-border-soft: rgba(249, 115, 22, 0.28);
-    --cp-color-border-strong: rgba(236, 72, 153, 0.45);
-    --cp-color-border-muted: rgba(253, 186, 116, 0.2);
-    --cp-color-text: #ffeefc;
-    --cp-color-text-muted: #f9a8d4;
-    --cp-color-accent: #ec4899;
-    --cp-color-accent-weak: rgba(236, 72, 153, 0.2);
-    --cp-color-accent-strong: #facc15;
-    --cp-color-positive: #4ade80;
-    --cp-color-warning: #fbbf24;
-    --cp-color-danger: #fb7185;
-    --cp-color-link: #f472b6;
-    --cp-button-bg: rgba(45, 14, 62, 0.78);
-    --cp-button-fg: #fff5fb;
-    --cp-button-border: rgba(236, 72, 153, 0.35);
-    --cp-button-border-strong: rgba(250, 204, 21, 0.4);
-    --cp-surface-translucent: color-mix(in srgb, #1d0821 92%, transparent);
-    --cp-surface-veil: color-mix(in srgb, #2a1033 74%, transparent);
-    --cp-surface-panel: color-mix(in srgb, #2a1033 64%, transparent);
-    --cp-overlay: rgba(17, 6, 24, 0.62);
-    --cp-gradient-bg: radial-gradient(130% 140% at 0% 0%, rgba(236, 72, 153, 0.18) 0%, transparent 60%), radial-gradient(140% 120% at 100% 0%, rgba(250, 204, 21, 0.12) 0%, transparent 60%), radial-gradient(160% 150% at 50% 100%, rgba(30, 8, 45, 0.92) 0%, rgba(14, 4, 19, 0.96) 100%);
-  }
+[data-theme='material-midnight'] {
+  color-scheme: dark;
 }
 
 html,
@@ -169,10 +145,8 @@ body {
 
 body {
   margin: 0;
-  color: var(--fg);
-  background-color: var(--bg);
-  background-image: var(--cp-gradient-bg);
-  background-attachment: fixed;
+  color: var(--md-sys-color-on-surface);
+  background-color: var(--md-sys-color-background);
   font-family: var(--font-sans);
   font-size: 16px;
   line-height: 1.6;
@@ -183,98 +157,25 @@ body {
   min-height: 100%;
 }
 
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  background-image:
-    linear-gradient(90deg, transparent 0, rgba(56, 189, 248, 0.12) 1px, transparent 2px),
-    linear-gradient(0deg, transparent 0, rgba(244, 114, 208, 0.1) 1px, transparent 2px);
-  background-size: 120px 120px;
-  opacity: 0.14;
-  mix-blend-mode: screen;
-  z-index: -1;
-}
-
 a {
-  color: var(--link);
-  text-decoration: none;
-  transition: color var(--transition-fast), text-shadow var(--transition-fast);
+  color: var(--md-comp-button-text-label);
+  text-decoration-color: color-mix(in srgb, currentColor 40%, transparent);
+  transition: color var(--transition-short), text-decoration-color var(--transition-short);
 }
 
 a:hover {
-  text-shadow: 0 0 12px color-mix(in srgb, var(--link) 60%, transparent);
+  color: color-mix(in srgb, var(--md-comp-button-text-label) 90%, black 10%);
+  text-decoration-color: color-mix(in srgb, currentColor 55%, transparent);
+}
+
+::selection {
+  background: color-mix(in srgb, var(--md-comp-button-text-label) 25%, transparent);
+  color: var(--md-sys-color-on-primary);
 }
 
 button,
 input,
-select,
-textarea {
-  font: inherit;
-  color: var(--fg);
-  background: var(--surface-translucent);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 0.55rem 0.85rem;
-  transition: border-color var(--transition-fast), box-shadow var(--transition-fast), transform var(--transition-fast);
-  box-shadow: none;
-}
-
-button {
-  cursor: pointer;
-  background: var(--btn-bg);
-  color: var(--btn-fg);
-  border: 1px solid var(--btn-border);
-  box-shadow: var(--shadow-button);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.72rem;
-}
-
-button:hover {
-  border-color: var(--accent);
-  box-shadow: var(--shadow-button-hover);
-}
-
-button:focus-visible,
-input:focus-visible,
-select:focus-visible,
-textarea:focus-visible {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 30%, transparent);
-}
-
-fieldset {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  padding: 1rem;
-}
-
-code,
-pre {
-  font-family: var(--font-mono);
-  background: color-mix(in srgb, var(--surface) 70%, transparent);
-  padding: 0.2rem 0.4rem;
-  border-radius: var(--radius-xs);
-}
-
-::selection {
-  background: color-mix(in srgb, var(--accent) 40%, transparent);
-  color: var(--bg);
-}
-
-.glass-panel {
-  background: var(--surface-panel);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-card);
-  backdrop-filter: blur(14px);
-}
-
-.surface-outline {
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border);
-  background: var(--surface-translucent);
+textarea,
+select {
+  font-family: inherit;
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,64 +1,61 @@
 UI Package
 
 Overview
-- Reusable Vue 3 components styled via CSS variables and utility classes.
-- Components expose consistent variant and size props for easy theming.
+- Reusable Vue 3 components aligned with Material 3 tokens, extensive variants, and motion presets.
+- Components expose consistent variant and size props for easy theming and adaptive layouts.
 
 Icon
 - Props:
   - name: one of sword|arrows|dice|plus|trash|book|info|download|copy|print|x|palette
   - size: xs|sm|md|lg|xl|inline (default sm)
-  - color: default|muted|accent|danger|fg|bg (default default)
+  - color: default|muted|accent|primary|success|danger|fg|bg (default default)
   - weight: outline|solid (default outline; Heroicons only)
 - Examples:
   - <AppIcon name="info" />
-  - <AppIcon name="print" weight="solid" size="lg" />
+  - <AppIcon name="print" weight="solid" size="lg" color="primary" />
   - <AppIcon name="palette" color="accent" size="inline" />
 
 Field Label
-- Props: label (string), icon?, tone: muted|fg|accent, size: xs|sm|md
-- Example: <AppFieldLabel label="Traits" icon="info" tone="fg" size="xs" />
+- Props: label (string), icon?, tone: muted|fg|accent|primary|secondary|success, size: xs|sm|md
+- Example: <AppFieldLabel label="Traits" icon="info" tone="primary" size="xs" />
 
 Buttons
 - AppButton
-  - variant: default|primary|secondary|danger|ghost|outline|subtle|accent (alias of primary)
+  - variant: filled|tonal|filled-tonal|outlined|text|ghost|surface|elevated|danger|success plus legacy aliases default|primary|secondary|accent|outline|subtle
   - size: xs|sm|md|lg, block?: boolean, loading?: boolean, disabled?: boolean
-  - Example: <AppButton variant="primary" size="md">Save</AppButton>
+  - Example: <AppButton variant="filled" size="md">Save</AppButton>
+  - Example tonal: <AppButton variant="tonal" size="sm">Secondary</AppButton>
 - AppIconButton
   - name: icon name, variant: same as AppButton, size: xs|sm|md|lg
-  - Example: <AppIconButton name="download" variant="outline" size="sm" />
+  - Example: <AppIconButton name="download" variant="outlined" size="sm" />
 
 Inputs
 - AppInput
-  - variant: outline|filled|ghost, size: sm|md|lg, invalid?: boolean
+  - variant: filled|outlined|text (outline alias), size: sm|md|lg, invalid?: boolean
   - Example: <AppInput variant="filled" size="lg" />
 - AppTextarea
-  - variant: outline|filled|ghost, size: sm|md|lg, rows?: number
+  - variant: filled|outlined|text, size: sm|md|lg, rows?: number
 - AppSelect
-  - variant: outline|filled|ghost, size: sm|md|lg, options?: {label,value}[]
+  - variant: filled|outlined|text, size: sm|md|lg, options?: {label,value}[]
 - AppTagInput
-  - variant: outline|filled|ghost, size: sm|md|lg
+  - variant: filled|outlined|text, size: sm|md|lg
 
 Card
 - AppCard
-  - variant: default|elevated|ghost
+  - variant: elevated|filled|surface|outlined|ghost (default elevated)
   - padding: sm|md|lg
-  - Example: <AppCard title="Details" variant="elevated" padding="lg">...</AppCard>
+  - Example: <AppCard title="Details" variant="outlined" padding="lg">...</AppCard>
 
 Shared Variant Utils
 - Import from package root or utils path:
   - import { cx, btnBase, btnSizes, btnVariants, iconBtnSizes } from '@my-monorepo/ui'
   - import { cx } from '@my-monorepo/ui/utils/variants'
 - cx(...parts): joins class segments conditionally.
-- btnBase, btnSizes, iconBtnSizes, btnVariants: used by AppButton/AppIconButton.
-
-Notes
-- Heroicons are integrated for common names; custom inline SVGs remain for sword/arrows/dice.
-- Icons always set explicit width/height so they don’t balloon without utilities.
+- btnBase, btnSizes, iconBtnSizes, btnVariants: used by AppButton/AppIconButton and align with Material transitions.
 
 Motion
 - Use Vue <Transition> with provided presets from `utils/motion`:
-  - import { fadeScale, fadeSlideUp, listItem, listMoveClass } from '@my-monorepo/ui/utils/motion'
+  - import { fadeScale, fadeSlideUp, fadeSlideRight, expandCollapse, pop, bottomSheet, listItem, listMoveClass, shimmerPulse } from '@my-monorepo/ui/utils/motion'
   - Example (menu):
     <Transition
       :enter-active-class="fadeScale.enterActiveClass"
@@ -85,15 +82,15 @@ Motion
     </TransitionGroup>
 
 Button Group
-- Props: modelValue (string), options [{label,value}], variant: default|primary|secondary|danger|ghost|outline|subtle|accent, size: sm|md|lg
+- Props: modelValue (string), options [{label,value}], variant same as AppButton, size: sm|md|lg
 - Examples:
-  - <AppButtonGroup :options="opts" :model-value="val" @update:modelValue="v => val=v" variant="primary" size="sm" />
+  - <AppButtonGroup :options="opts" :model-value="val" @update:modelValue="v => val=v" variant="filled" size="sm" />
   - <AppButtonGroup :options="opts" variant="ghost" />
 
 Dropdown
 - Props: items [{label,value,icon?}], align: left|right, buttonTitle, variant, size
 - Example:
-  <AppDropdown :items="[{label:'Copy',value:'copy',icon:'copy'}]" variant="outline" size="sm">
+  <AppDropdown :items="[{label:'Copy',value:'copy',icon:'copy'}]" variant="outlined" size="sm">
     <template #button>
       <AppIcon name="plus" />
       <span>Actions</span>
@@ -110,15 +107,16 @@ Layout
 
 Text
 - AppText
-  - Props: as='p|div|span|...', variant: body|muted|caption|mono|small|lead, tone: fg|muted|accent, size: xs|sm|md|lg
-  - Example: <AppText variant="caption" tone="accent">Header</AppText>
+  - Props: as='p|div|span|...', variant: body|muted|caption|label|title|display|mono, tone: fg|muted|accent|primary|secondary|success, size: xs|sm|md|lg
+  - Example: <AppText variant="label" tone="primary">Header</AppText>
 
 Types
 - Import shared types directly from the package root:
-  - import type { ButtonVariant, ButtonSize, ControlVariant, ControlSize, Tone, IconSize, IconColor, IconWeight, DropdownAlign } from '@my-monorepo/ui'
+  - import type { ButtonVariant, ButtonSize, ControlVariant, ControlSize, Tone, IconSize, IconColor, IconWeight, DropdownAlign }
+    from '@my-monorepo/ui'
 - These mirror the props across components to help standardize usage.
 
 Badge
 - AppBadge
-  - Props: variant: default|accent|neutral|danger|success; size: xs|sm|md
-  - Example: <AppBadge variant="accent" size="xs">Beta</AppBadge>
+  - Props: variant: surface|primary|secondary|neutral|danger|success|accent; size: xs|sm|md
+  - Example: <AppBadge variant="primary" size="xs">Beta</AppBadge>

--- a/packages/ui/src/components/AppBadge.vue
+++ b/packages/ui/src/components/AppBadge.vue
@@ -1,25 +1,34 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { cx } from '../utils/variants'
+
+const sizeMap: Record<'xs'|'sm'|'md', string> = {
+  xs: 'px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.16em]',
+  sm: 'px-2.5 py-0.5 text-[0.72rem] uppercase tracking-[0.16em]',
+  md: 'px-3 py-1 text-[0.78rem] uppercase tracking-[0.16em]'
+}
+
+const variantMap: Record<string, string> = {
+  surface: 'bg-[color:var(--md-sys-color-surface-container-high)] text-[color:var(--md-sys-color-on-surface)] border-[color:var(--md-sys-color-outline-variant)]',
+  primary: 'bg-[color:var(--md-sys-color-primary-container)] text-[color:var(--md-sys-color-on-primary-container)] border-[color:var(--md-sys-color-primary)]',
+  accent: 'bg-[color:var(--md-sys-color-primary-container)] text-[color:var(--md-sys-color-on-primary-container)] border-[color:var(--md-sys-color-primary)]',
+  neutral: 'bg-[color:var(--md-sys-color-surface-variant)] text-[color:var(--md-sys-color-on-surface-variant)] border-[color:var(--md-sys-color-outline)]',
+  secondary: 'bg-[color:var(--md-sys-color-secondary-container)] text-[color:var(--md-sys-color-on-secondary-container)] border-[color:var(--md-sys-color-secondary)]',
+  danger: 'bg-[color:var(--md-sys-color-error-container)] text-[color:var(--md-sys-color-on-error-container)] border-[color:var(--md-sys-color-error)]',
+  success: 'bg-[color:var(--md-sys-color-success-container)] text-[color:var(--md-sys-color-on-success-container)] border-[color:var(--md-sys-color-success)]',
+  default: 'bg-[color:var(--md-sys-color-surface-variant)] text-[color:var(--md-sys-color-on-surface-variant)] border-[color:var(--md-sys-color-outline)]'
+}
+
 const props = withDefaults(defineProps<{
-  variant?: 'default' | 'accent' | 'neutral' | 'danger' | 'success'
+  variant?: 'surface'|'primary'|'secondary'|'danger'|'success'|'accent'|'neutral'|'default'
   size?: 'xs'|'sm'|'md'
-}>(), { variant: 'neutral', size: 'sm' })
+}>(), { variant: 'surface', size: 'sm' })
 
-const map: Record<string, string> = {
-  default: 'bg-[color:var(--surface-veil)] text-[color:var(--fg)] border-[color:var(--border)]',
-  accent: 'bg-[color:var(--accent-weak)] text-[color:var(--accent)] border-[color:var(--accent)]',
-  neutral: 'bg-[color:var(--surface-translucent)] text-[color:var(--muted)] border-[color:var(--border-muted)]',
-  danger: 'bg-[color:var(--danger-soft)] text-[color:var(--enemy-accent)] border-[color:var(--danger-border)]',
-  success: 'bg-[color:var(--success-soft)] text-[color:var(--env-accent)] border-[color:var(--success-border)]',
-}
-
-const sizeMap: Record<string, string> = {
-  xs: 'px-2 py-0.5 text-[0.56rem] tracking-[0.22em] gap-0.5',
-  sm: 'px-3 py-1 text-[0.62rem] tracking-[0.24em] gap-1',
-  md: 'px-3.5 py-1.5 text-[0.68rem] tracking-[0.26em] gap-1.5',
-}
-
-const klass = computed(() => ['inline-flex items-center rounded-[var(--radius-pill)] border font-semibold uppercase', sizeMap[props.size], map[props.variant]].join(' '))
+const klass = computed(() => cx(
+  'inline-flex items-center rounded-[var(--radius-pill)] border font-semibold',
+  sizeMap[props.size],
+  variantMap[props.variant] ?? variantMap.surface
+))
 </script>
 
 <template>
@@ -27,4 +36,3 @@ const klass = computed(() => ['inline-flex items-center rounded-[var(--radius-pi
     <slot />
   </span>
 </template>
-

--- a/packages/ui/src/components/AppButton.vue
+++ b/packages/ui/src/components/AppButton.vue
@@ -1,24 +1,62 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { btnBase, btnSizes, btnVariants, cx } from '../utils/variants'
+import type { ButtonVariant } from '../types'
 
 const props = withDefaults(defineProps<{
-  variant?: 'default' | 'primary' | 'secondary' | 'danger' | 'ghost' | 'outline' | 'subtle' | 'accent'
+  variant?: ButtonVariant
   size?: 'xs' | 'sm' | 'md' | 'lg'
   block?: boolean
   loading?: boolean
   disabled?: boolean
-}>(), { variant: 'default', size: 'md', block: false, loading: false, disabled: false })
+}>(), { variant: 'filled', size: 'md', block: false, loading: false, disabled: false })
 
-const variantKey = computed(() => props.variant === 'accent' ? 'primary' : props.variant)
+const aliasMap: Record<ButtonVariant, keyof typeof btnVariants> = {
+  filled: 'filled',
+  tonal: 'tonal',
+  'filled-tonal': 'tonal',
+  outlined: 'outlined',
+  outline: 'outlined',
+  text: 'text',
+  elevated: 'elevated',
+  surface: 'surface',
+  ghost: 'ghost',
+  danger: 'danger',
+  success: 'success',
+  default: 'elevated',
+  primary: 'filled',
+  secondary: 'tonal',
+  accent: 'filled',
+  subtle: 'surface'
+}
+
+const normalizedVariant = computed(() => aliasMap[props.variant] ?? 'filled')
+
+const klass = computed(() => cx(
+  btnBase,
+  btnSizes[props.size],
+  btnVariants[normalizedVariant.value] ?? btnVariants.filled,
+  props.block ? 'w-full' : '',
+  props.disabled || props.loading ? 'pointer-events-none opacity-60' : ''
+))
 </script>
 
 <template>
-  <button :disabled="props.disabled || props.loading" :class="cx(btnBase, btnSizes[props.size], btnVariants[variantKey], props.block ? 'w-full' : '', (props.disabled||props.loading) ? 'opacity-60 cursor-not-allowed' : '')">
-    <svg v-if="props.loading" class="mr-2 h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <circle class="opacity-25" cx="12" cy="12" r="10" stroke-width="4" />
-      <path class="opacity-75" d="M4 12a8 8 0 0 1 8-8" stroke-width="4" />
-    </svg>
-    <slot />
+  <button
+    :disabled="props.disabled || props.loading"
+    :aria-busy="props.loading ? 'true' : 'false'"
+    :data-variant="normalizedVariant"
+    :class="klass"
+  >
+    <span v-if="props.loading" class="flex items-center gap-2">
+      <svg class="h-4 w-4 animate-spin text-current" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke-width="3" />
+        <path class="opacity-75" d="M4 12a8 8 0 0 1 8-8" stroke-width="3" stroke-linecap="round" />
+      </svg>
+      <slot name="loading">Loading…</slot>
+    </span>
+    <span v-else class="flex items-center gap-2">
+      <slot />
+    </span>
   </button>
 </template>

--- a/packages/ui/src/components/AppButtonGroup.vue
+++ b/packages/ui/src/components/AppButtonGroup.vue
@@ -1,35 +1,101 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { cx } from '../utils/variants'
+import type { ButtonVariant, ButtonSize } from '../types'
 
 const props = withDefaults(defineProps<{
   modelValue: string
   options: { label: string; value: string }[]
-  size?: 'sm'|'md'|'lg'
-  variant?: 'default'|'primary'|'secondary'|'danger'|'ghost'|'outline'|'subtle'|'accent'
-}>(), { size: 'md', variant: 'default' })
+  size?: ButtonSize
+  variant?: ButtonVariant
+}>(), { size: 'md', variant: 'surface' })
 const emit = defineEmits<{ (e:'update:modelValue', v:string): void }>()
 
-const sizeClass = computed(() => props.size==='sm' ? 'py-1.5 text-[0.62rem]' : props.size==='lg' ? 'py-2.5 text-[0.82rem]' : 'py-2 text-[0.72rem]')
+const sizeClass = computed(() => props.size==='sm' ? 'py-1.5 text-[0.7rem]' : props.size==='lg' ? 'py-2.5 text-[0.86rem]' : 'py-2 text-[0.78rem]')
+
+const containerClass = computed(() => normalizeVariant(props.variant) === 'ghost'
+  ? 'border-transparent bg-transparent shadow-none'
+  : 'border border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface-container-high)] shadow-[var(--shadow-level1)]')
+
+function normalizeVariant(variant: ButtonVariant): 'filled' | 'tonal' | 'surface' | 'outlined' | 'text' | 'ghost' | 'danger' | 'success' {
+  switch (variant) {
+    case 'primary':
+    case 'accent':
+    case 'filled':
+      return 'filled'
+    case 'secondary':
+    case 'tonal':
+    case 'filled-tonal':
+      return 'tonal'
+    case 'outline':
+    case 'outlined':
+      return 'outlined'
+    case 'ghost':
+    case 'text':
+      return 'ghost'
+    case 'danger':
+      return 'danger'
+    case 'success':
+      return 'success'
+    case 'default':
+    case 'elevated':
+      return 'surface'
+    case 'subtle':
+    case 'surface':
+    default:
+      return 'surface'
+  }
+}
+
+function palette(active: boolean) {
+  const normalized = normalizeVariant(props.variant)
+  if (active) {
+    switch (normalized) {
+      case 'filled':
+        return 'bg-[color:var(--md-comp-button-filled-container)] text-[color:var(--md-comp-button-filled-on-container)] border-[color:var(--md-comp-button-filled-container)]'
+      case 'tonal':
+        return 'bg-[color:var(--md-comp-button-tonal-container)] text-[color:var(--md-comp-button-tonal-on-container)] border-[color:var(--md-comp-button-tonal-container)]'
+      case 'outlined':
+        return 'bg-[color:var(--md-comp-button-outlined-hover-layer)] text-[color:var(--md-comp-button-text-label)] border-[color:var(--md-comp-button-text-label)]'
+      case 'ghost':
+        return 'bg-[color:var(--md-comp-button-ghost-hover-layer)] text-[color:var(--md-comp-button-ghost-label)] border-transparent'
+      case 'danger':
+        return 'bg-[color:var(--md-comp-button-danger-container)] text-[color:var(--md-comp-button-danger-on-container)] border-[color:var(--md-comp-button-danger-container)]'
+      case 'success':
+        return 'bg-[color:var(--md-comp-button-success-container)] text-[color:var(--md-comp-button-success-on-container)] border-[color:var(--md-comp-button-success-container)]'
+      case 'surface':
+      default:
+        return 'bg-[color:var(--md-sys-color-surface-container-high)] text-[color:var(--md-sys-color-on-surface)] border-[color:var(--md-sys-color-outline-variant)]'
+    }
+  }
+
+  switch (normalized) {
+    case 'filled':
+      return 'bg-transparent border-[color:var(--md-comp-button-filled-container)] text-[color:var(--md-comp-button-filled-container)] hover:bg-[color:var(--md-comp-button-outlined-hover-layer)]'
+    case 'tonal':
+      return 'bg-transparent border-[color:var(--md-comp-button-tonal-container)] text-[color:var(--md-comp-button-tonal-container)] hover:bg-[color:var(--md-comp-button-outlined-hover-layer)]'
+    case 'outlined':
+      return 'bg-transparent border-[color:var(--md-comp-button-outlined-outline)] text-[color:var(--md-comp-button-text-label)] hover:bg-[color:var(--md-comp-button-outlined-hover-layer)]'
+    case 'ghost':
+      return 'bg-transparent border-transparent text-[color:var(--md-comp-button-ghost-label)] hover:bg-[color:var(--md-comp-button-ghost-hover-layer)]'
+    case 'danger':
+      return 'bg-transparent border-[color:var(--md-comp-button-danger-container)] text-[color:var(--md-comp-button-danger-container)] hover:bg-[color:var(--md-comp-button-outlined-hover-layer)]'
+    case 'success':
+      return 'bg-transparent border-[color:var(--md-comp-button-success-container)] text-[color:var(--md-comp-button-success-container)] hover:bg-[color:var(--md-comp-button-outlined-hover-layer)]'
+    case 'surface':
+    default:
+      return 'bg-transparent border-[color:var(--md-sys-color-outline-variant)] text-[color:var(--md-sys-color-on-surface-variant)] hover:bg-[color:var(--md-comp-button-ghost-hover-layer)]'
+  }
+}
 
 function itemClass(active: boolean) {
-  const base = 'px-3 transition-all duration-150 uppercase tracking-[0.14em] font-semibold border-r last:border-r-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--surface)]'
-  const paletteActive = props.variant==='primary' || props.variant==='accent'
-    ? 'bg-[color:var(--accent)] text-[color:var(--bg)] shadow-[var(--shadow-button-hover)] border-[color:var(--accent)]'
-    : props.variant==='danger'
-    ? 'bg-[#fb7185] text-white shadow-[var(--shadow-button-hover)] border-[#fb7185]'
-    : 'bg-[color:var(--surface-veil)] text-[color:var(--fg)] border-[color:var(--btn-border)]'
-  const paletteIdle = props.variant==='ghost'
-    ? 'text-[color:var(--fg)] border-transparent hover:bg-[color:var(--surface-translucent)]'
-    : props.variant==='outline'
-    ? 'text-[color:var(--fg)] border-[color:var(--btn-border)] hover:bg-[color:var(--surface-veil)]'
-    : 'text-[color:var(--fg)] border-[color:var(--btn-border)] hover:bg-[color:var(--surface-veil)]'
-  return cx(base, sizeClass.value, active ? paletteActive : paletteIdle)
+  const base = 'px-3 transition-all duration-[var(--transition-short)] uppercase tracking-[0.12em] font-semibold border-r last:border-r-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--md-comp-focus-ring)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--md-sys-color-surface)]'
+  return cx(base, sizeClass.value, palette(active))
 }
 </script>
 
 <template>
-  <div :class="cx('inline-flex overflow-hidden rounded-[var(--radius-sm)] shadow-[var(--shadow-soft)] backdrop-blur-sm', props.variant==='ghost' ? 'border-transparent bg-transparent' : 'border border-[color:var(--btn-border)] bg-[color:var(--surface-translucent)]')">
+  <div :class="cx('inline-flex overflow-hidden rounded-[var(--radius-md)] backdrop-blur-sm', containerClass.value)">
     <button
       v-for="opt in props.options"
       :key="opt.value"
@@ -41,4 +107,3 @@ function itemClass(active: boolean) {
     </button>
   </div>
 </template>
-

--- a/packages/ui/src/components/AppCard.vue
+++ b/packages/ui/src/components/AppCard.vue
@@ -1,21 +1,33 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { cx } from '../utils/variants'
+
 const props = withDefaults(defineProps<{
   title?: string
-  variant?: 'default'|'elevated'|'ghost'
+  variant?: 'filled'|'elevated'|'outlined'|'surface'|'ghost'|'default'
   padding?: 'sm'|'md'|'lg'
-}>(), { variant: 'default', padding: 'md' })
+}>(), { variant: 'elevated', padding: 'md' })
+
+const variantClass = computed(() => {
+  const map: Record<string, string> = {
+    filled: 'bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--md-sys-color-outline-variant)] shadow-[var(--shadow-level1)]',
+    surface: 'bg-[color:var(--md-sys-color-surface-container)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--md-sys-color-outline-variant)] shadow-[var(--shadow-level1)]',
+    elevated: 'bg-[color:var(--md-sys-color-surface-container-high)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--md-sys-color-outline-variant)] shadow-[var(--shadow-level2)]',
+    outlined: 'bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--md-sys-color-outline)] shadow-none',
+    ghost: 'bg-transparent border border-transparent shadow-none',
+    default: 'bg-[color:var(--md-sys-color-surface-container)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--md-sys-color-outline-variant)] shadow-[var(--shadow-level1)]'
+  }
+  return map[props.variant] ?? map.elevated
+})
+
+const paddingClass = computed(() => props.padding === 'sm' ? 'p-4' : props.padding === 'lg' ? 'p-8' : 'p-6')
 </script>
 
 <template>
-  <section :class="[
-    'rounded-[var(--radius-lg)] backdrop-blur-md',
-    props.variant==='ghost' ? 'border-transparent bg-transparent shadow-none' : '',
-    props.variant==='elevated' ? 'border border-[color:var(--border)] bg-[color:var(--surface-panel)] shadow-[var(--shadow-elevated)]' : '',
-    props.variant==='default' ? 'border border-[color:var(--border)] bg-[color:var(--surface-panel)] shadow-[var(--shadow-card)]' : '',
-    props.padding==='sm' ? 'p-3' : (props.padding==='lg' ? 'p-6' : 'p-5')
-  ]">
-    <h2 v-if="props.title" class="mb-3 text-base font-semibold">{{ props.title }}</h2>
+  <section :class="cx('rounded-[var(--radius-lg)] transition-shadow duration-[var(--transition-short)] backdrop-blur-sm', variantClass.value, paddingClass.value)">
+    <header v-if="props.title" class="mb-4">
+      <h2 class="font-semibold text-[1.05rem] tracking-[0.04em] text-[color:var(--md-sys-color-on-surface)]">{{ props.title }}</h2>
+    </header>
     <slot />
   </section>
 </template>
-

--- a/packages/ui/src/components/AppDropdown.vue
+++ b/packages/ui/src/components/AppDropdown.vue
@@ -1,20 +1,22 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { cx, btnBase, btnSizes, btnVariants } from '../utils/variants'
+import { fadeScale } from '../utils/motion'
 import AppIcon from './AppIcon.vue'
+import type { ButtonVariant, ButtonSize, DropdownAlign } from '../types'
 
 type Item = { label: string; value: string; icon?: 'sword'|'book'|'download'|'copy'|'print'|'info'|'plus'|'palette' }
 
 const props = withDefaults(defineProps<{
   items: Item[]
-  align?: 'left' | 'right'
+  align?: DropdownAlign
   buttonTitle?: string
-  variant?: 'default'|'primary'|'secondary'|'danger'|'ghost'|'outline'|'subtle'|'accent'
-  size?: 'xs'|'sm'|'md'|'lg'
-}>(), { align: 'left', buttonTitle: '', variant: 'default', size: 'md' })
+  variant?: ButtonVariant
+  size?: ButtonSize
+}>(), { align: 'left', buttonTitle: '', variant: 'surface', size: 'md' })
 
 const emit = defineEmits<{ (e:'select', v:string): void }>()
-const itemSize = (size: 'xs'|'sm'|'md'|'lg') => size==='xs' ? 'px-3 py-1.5 text-[0.62rem]' : size==='lg' ? 'px-3 py-2.5 text-[0.82rem]' : size==='sm' ? 'px-3 py-1.5 text-[0.68rem]' : 'px-3 py-2 text-[0.72rem]'
+const itemSize = (size: ButtonSize) => size==='xs' ? 'px-3 py-1.5 text-[0.66rem]' : size==='lg' ? 'px-3 py-2.5 text-[0.84rem]' : size==='sm' ? 'px-3 py-1.5 text-[0.72rem]' : 'px-3 py-2 text-[0.78rem]'
 
 const open = ref(false)
 const root = ref<HTMLElement | null>(null)
@@ -39,25 +41,25 @@ function choose(v: string) {
       :title="props.buttonTitle"
       type="button"
       @click="open = !open"
-      :class="cx(btnBase, btnSizes[props.size], btnVariants[props.variant==='accent'?'primary':props.variant])"
+      :class="cx(btnBase, btnSizes[props.size], btnVariants[props.variant] ?? btnVariants.surface)"
     >
       <slot name="button" />
     </button>
     <Transition
-      enter-active-class="transition ease-out duration-150"
-      enter-from-class="opacity-0 translate-y-1 scale-95"
-      enter-to-class="opacity-100 translate-y-0 scale-100"
-      leave-active-class="transition ease-in duration-100"
-      leave-from-class="opacity-100 translate-y-0 scale-100"
-      leave-to-class="opacity-0 translate-y-1 scale-95"
+      :enter-active-class="fadeScale.enterActiveClass"
+      :enter-from-class="fadeScale.enterFromClass"
+      :enter-to-class="fadeScale.enterToClass"
+      :leave-active-class="fadeScale.leaveActiveClass"
+      :leave-from-class="fadeScale.leaveFromClass"
+      :leave-to-class="fadeScale.leaveToClass"
     >
-      <div v-if="open" :class="['absolute z-50 mt-2 w-52 overflow-hidden rounded-[var(--radius-md)] border border-[color:var(--border)] bg-[color:var(--surface-panel)] shadow-[var(--shadow-elevated)] backdrop-blur-lg', props.align==='right' ? 'right-0' : 'left-0']">
+      <div v-if="open" :class="['absolute z-50 mt-2 min-w-[12rem] overflow-hidden rounded-[var(--radius-lg)] border border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface-container-high)] shadow-[var(--shadow-level3)] backdrop-blur-md', props.align==='right' ? 'right-0' : 'left-0']">
         <button
           v-for="it in props.items"
           :key="it.value"
           type="button"
           @click="choose(it.value)"
-          :class="['flex w-full items-center gap-3 text-left font-semibold uppercase tracking-[0.12em] text-[color:var(--fg)] transition-colors hover:bg-[color:var(--surface-veil)] focus-visible:outline-none focus-visible:bg-[color:var(--surface-veil)]', itemSize(props.size)]"
+          :class="['flex w-full items-center gap-3 text-left font-medium uppercase tracking-[0.08em] text-[color:var(--md-sys-color-on-surface)] transition-colors duration-[var(--transition-short)] hover:bg-[color:var(--md-comp-button-ghost-hover-layer)] focus-visible:outline-none focus-visible:bg-[color:var(--md-comp-button-ghost-hover-layer)]', itemSize(props.size)]"
         >
           <AppIcon v-if="it.icon" :name="it.icon" />
           <span>{{ it.label }}</span>
@@ -66,4 +68,3 @@ function choose(v: string) {
     </Transition>
   </div>
 </template>
-

--- a/packages/ui/src/components/AppFieldLabel.vue
+++ b/packages/ui/src/components/AppFieldLabel.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import AppIcon from './AppIcon.vue'
+import type { Tone, TextSize } from '../types'
 
-type Tone = 'muted' | 'fg' | 'accent'
-type Size = 'xs' | 'sm' | 'md'
+type Size = Extract<TextSize, 'xs' | 'sm' | 'md'>
 
 const props = withDefaults(defineProps<{
   icon?: 'sword'|'arrows'|'dice'|'book'|'info'
@@ -13,29 +13,34 @@ const props = withDefaults(defineProps<{
 }>(), { tone: 'muted', size: 'sm' })
 
 const klass = computed(() => {
-  const base = 'flex items-center gap-1 font-semibold uppercase'
+  const base = 'flex items-center gap-1 font-semibold uppercase tracking-[0.28em] text-[0.7rem]'
   const size = props.size === 'xs'
-    ? 'mb-0.5 text-[0.56rem] tracking-[0.26em]'
+    ? 'mb-0.5 text-[0.6rem]'
     : props.size === 'md'
-    ? 'mb-1.5 text-[0.68rem] tracking-[0.3em]'
-    : 'mb-1 text-[0.62rem] tracking-[0.28em]'
-  const tone = props.tone === 'fg'
-    ? 'text-[color:var(--fg)]'
-    : props.tone === 'accent'
-    ? 'text-[color:var(--accent)]'
-    : 'text-[color:var(--muted)]'
+    ? 'mb-1.5 text-[0.74rem]'
+    : 'mb-1 text-[0.68rem]'
+  const tone = props.tone === 'accent' || props.tone === 'primary'
+    ? 'text-[color:var(--md-sys-color-primary)]'
+    : props.tone === 'fg'
+    ? 'text-[color:var(--md-sys-color-on-surface)]'
+    : props.tone === 'secondary'
+    ? 'text-[color:var(--md-sys-color-secondary)]'
+    : props.tone === 'success'
+    ? 'text-[color:var(--md-sys-color-success)]'
+    : 'text-[color:var(--md-sys-color-on-surface-variant)]'
   return [base, size, tone].join(' ')
 })
-
-// Keep the icon aligned with text by default
-// so it scales with label size.
 </script>
 
 <template>
   <div :class="klass">
-    <AppIcon v-if="props.icon" :name="props.icon" size="inline" :color="props.tone === 'accent' ? 'accent' : (props.tone === 'fg' ? 'fg' : 'muted')" />
+    <AppIcon
+      v-if="props.icon"
+      :name="props.icon"
+      size="inline"
+      :color="props.tone === 'accent' || props.tone === 'primary' ? 'primary' : props.tone === 'fg' ? 'fg' : props.tone === 'success' ? 'success' : 'muted'"
+    />
     <span>{{ props.label }}</span>
     <slot />
   </div>
 </template>
-

--- a/packages/ui/src/components/AppIcon.vue
+++ b/packages/ui/src/components/AppIcon.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import {
+import { 
   InformationCircleIcon,
   BookOpenIcon,
   TrashIcon,
@@ -14,7 +14,7 @@ import {
   XMarkIcon,
   PaintBrushIcon,
 } from '@heroicons/vue/24/outline'
-import {
+import { 
   InformationCircleIcon as InformationCircleIconSolid,
   BookOpenIcon as BookOpenIconSolid,
   TrashIcon as TrashIconSolid,
@@ -29,10 +29,9 @@ import {
   PaintBrushIcon as PaintBrushIconSolid,
 } from '@heroicons/vue/24/solid'
 
+import type { IconColor, IconSize, IconWeight } from '../types'
+
 type IconName = 'sword'|'arrows'|'dice'|'plus'|'trash'|'book'|'info'|'download'|'copy'|'print'|'x'|'palette'
-type IconSize = 'xs'|'sm'|'md'|'lg'|'xl'|'inline'
-type IconColor = 'default'|'muted'|'accent'|'danger'|'fg'|'bg'
-type IconWeight = 'outline'|'solid'
 
 const props = withDefaults(
   defineProps<{
@@ -56,11 +55,13 @@ const sizeClass = computed(() => ({
 
 const colorClass = computed(() => ({
   default: '',
-  muted: 'text-[color:var(--muted)]',
-  accent: 'text-[color:var(--accent)]',
-  danger: 'text-[#fb7185]',
-  fg: 'text-[color:var(--fg)]',
-  bg: 'text-[color:var(--bg)]',
+  muted: 'text-[color:var(--md-sys-color-on-surface-variant)]',
+  accent: 'text-[color:var(--md-sys-color-primary)]',
+  primary: 'text-[color:var(--md-sys-color-primary)]',
+  danger: 'text-[color:var(--md-sys-color-error)]',
+  success: 'text-[color:var(--md-sys-color-success)]',
+  fg: 'text-[color:var(--md-sys-color-on-surface)]',
+  bg: 'text-[color:var(--md-sys-color-surface)]',
 }[props.color]))
 
 // Provide explicit dimensions via style to avoid environments

--- a/packages/ui/src/components/AppIconButton.vue
+++ b/packages/ui/src/components/AppIconButton.vue
@@ -2,24 +2,52 @@
 import { computed } from 'vue'
 import AppIcon from './AppIcon.vue'
 import { btnBase, btnVariants, iconBtnSizes, cx } from '../utils/variants'
+import type { ButtonVariant, IconButtonSize } from '../types'
+
 const props = withDefaults(defineProps<{
   name: 'sword'|'arrows'|'dice'|'plus'|'trash'|'book'|'info'|'download'|'copy'|'print'|'x'|'palette'
-  variant?: 'default'|'primary'|'secondary'|'danger'|'ghost'|'outline'|'subtle'|'accent'
-  size?: 'xs'|'sm'|'md'|'lg'
+  variant?: ButtonVariant
+  size?: IconButtonSize
   title?: string
-}>(), { variant: 'outline', size: 'sm', title: '' })
+}>(), { variant: 'outlined', size: 'sm', title: '' })
 
-const iconSizeMap: Record<string, 'xs'|'sm'|'md'|'lg'|'xl'|'inline'> = {
+const iconSizeMap: Record<IconButtonSize, 'xs'|'sm'|'md'|'lg'|'xl'|'inline'> = {
   xs: 'xs',
   sm: 'sm',
   md: 'md',
-  lg: 'lg',
+  lg: 'lg'
 }
-const variantKey = computed(() => props.variant === 'accent' ? 'primary' : props.variant)
+
+const aliasMap: Record<ButtonVariant, keyof typeof btnVariants> = {
+  filled: 'filled',
+  tonal: 'tonal',
+  'filled-tonal': 'tonal',
+  outlined: 'outlined',
+  outline: 'outlined',
+  text: 'text',
+  elevated: 'elevated',
+  surface: 'surface',
+  ghost: 'ghost',
+  danger: 'danger',
+  success: 'success',
+  default: 'elevated',
+  primary: 'filled',
+  secondary: 'tonal',
+  accent: 'filled',
+  subtle: 'surface'
+}
+
+const normalizedVariant = computed(() => aliasMap[props.variant] ?? 'outlined')
+
+const klass = computed(() => cx(
+  btnBase,
+  iconBtnSizes[props.size],
+  btnVariants[normalizedVariant.value] ?? btnVariants.outlined
+))
 </script>
 
 <template>
-  <button :title="props.title" :class="cx(btnBase, iconBtnSizes[props.size], btnVariants[variantKey])">
+  <button :title="props.title" :aria-label="props.title || props.name" :class="klass">
     <AppIcon :name="props.name" :size="iconSizeMap[props.size]" />
   </button>
 </template>

--- a/packages/ui/src/components/AppInput.vue
+++ b/packages/ui/src/components/AppInput.vue
@@ -1,26 +1,55 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import type { ControlVariant, ControlSize } from '../types'
+
 const props = withDefaults(defineProps<{
   modelValue?: string | number | null
   type?: string
   placeholder?: string
-  variant?: 'outline' | 'filled' | 'ghost'
+  variant?: ControlVariant
   invalid?: boolean
-  size?: 'sm' | 'md' | 'lg'
-}>(), { type: 'text', placeholder: '', variant: 'outline', invalid: false, size: 'md' })
+  size?: ControlSize
+}>(), { type: 'text', placeholder: '', variant: 'outlined', invalid: false, size: 'md' })
+
 const emit = defineEmits<{ (e: 'update:modelValue', v: any): void }>()
 
-const klass = computed(() => {
-  const size = props.size === 'sm' ? 'px-2.5 py-1.5 text-[0.68rem]' : props.size === 'lg' ? 'px-3.5 py-2.5 text-[0.82rem]' : 'px-3 py-2 text-[0.75rem]'
-  const base = `w-full rounded-[var(--radius-sm)] border ${size} transition-all duration-150 text-[color:var(--fg)] placeholder:text-[color:var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--surface)]`
-  const palette = props.variant === 'filled'
-    ? 'bg-[color:var(--surface-veil)] border-[color:var(--border)]'
-    : props.variant === 'ghost'
-    ? 'bg-transparent border-transparent focus-visible:border-[color:var(--accent)]'
-    : 'bg-[color:var(--surface-translucent)] border-[color:var(--btn-border)]'
-  const invalid = props.invalid ? 'border-[rgba(251,113,133,0.6)] focus-visible:ring-[rgba(251,113,133,0.4)] focus-visible:border-[rgba(251,113,133,0.9)]' : ''
-  return [base, palette, invalid].join(' ')
+const sizeClass = computed(() => {
+  switch (props.size) {
+    case 'sm':
+      return 'px-3 py-2 text-[0.75rem]'
+    case 'lg':
+      return 'px-4 py-3 text-[0.88rem]'
+    default:
+      return 'px-3.5 py-2.5 text-[0.82rem]'
+  }
 })
+
+const variantClass = computed(() => {
+  const alias: Record<ControlVariant, ControlVariant> = {
+    filled: 'filled',
+    outlined: 'outlined',
+    outline: 'outlined',
+    text: 'text'
+  }
+  const key = alias[props.variant] ?? 'outlined'
+  const map: Record<string, string> = {
+    filled: 'bg-[color:var(--md-comp-field-container)] border border-transparent focus-visible:ring-offset-[color:var(--md-comp-field-container)] hover:bg-[color:color-mix(in_srgb,var(--md-comp-field-container) 96%, var(--md-sys-color-surface-tint) 4%)]',
+    outlined: 'bg-transparent border border-[color:var(--md-comp-field-outline)] hover:border-[color:var(--md-sys-color-primary)] focus-visible:ring-offset-[color:var(--md-sys-color-surface)]',
+    text: 'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--md-comp-field-outline)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:var(--md-sys-color-primary)]'
+  }
+  return map[key] ?? map.outlined
+})
+
+const invalidClass = computed(() => props.invalid
+  ? 'border-[color:var(--md-sys-color-error)] focus-visible:ring-[color:var(--md-sys-color-error)] focus-visible:ring-offset-[color:var(--md-sys-color-error-container)]'
+  : '')
+
+const klass = computed(() => [
+  'w-full rounded-[var(--radius-md)] transition-all duration-[var(--transition-short)] text-[color:var(--md-comp-field-on-surface)] placeholder:text-[color:var(--md-comp-field-placeholder)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--md-comp-focus-ring)]',
+  sizeClass.value,
+  variantClass.value,
+  invalidClass.value
+].join(' '))
 </script>
 
 <template>
@@ -28,6 +57,8 @@ const klass = computed(() => {
     :type="props.type"
     :placeholder="props.placeholder"
     :value="props.modelValue ?? ''"
+    :data-variant="props.variant"
+    :aria-invalid="props.invalid ? 'true' : 'false'"
     @input="emit('update:modelValue', (props.type==='number' ? Number(($event.target as HTMLInputElement).value) || null : ($event.target as HTMLInputElement).value))"
     :class="klass"
   />

--- a/packages/ui/src/components/AppSelect.vue
+++ b/packages/ui/src/components/AppSelect.vue
@@ -1,31 +1,63 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import type { ControlVariant, ControlSize } from '../types'
+
 type Option = { label: string; value: string }
+
 const props = withDefaults(defineProps<{
   modelValue?: string
   options?: Option[]
-  variant?: 'outline' | 'filled' | 'ghost'
+  variant?: ControlVariant
   invalid?: boolean
-  size?: 'sm'|'md'|'lg'
-}>(), { options: () => [], variant: 'outline', invalid: false, size: 'md' })
+  size?: ControlSize
+}>(), { options: () => [], variant: 'outlined', invalid: false, size: 'md' })
+
 const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
 
-const klass = computed(() => {
-  const size = props.size === 'sm' ? 'px-2.5 py-1.5 text-[0.68rem]' : props.size === 'lg' ? 'px-3.5 py-2.5 text-[0.82rem]' : 'px-2.5 py-2 text-[0.75rem]'
-  const base = `w-full rounded-[var(--radius-sm)] border ${size} transition-all duration-150 text-[color:var(--fg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--surface)]`
-  const palette = props.variant === 'filled'
-    ? 'bg-[color:var(--surface-veil)] border-[color:var(--border)]'
-    : props.variant === 'ghost'
-    ? 'bg-transparent border-transparent focus-visible:border-[color:var(--accent)] text-[color:var(--fg)]'
-    : 'bg-[color:var(--surface-translucent)] border-[color:var(--btn-border)] text-[color:var(--fg)]'
-  const invalid = props.invalid ? 'border-[rgba(251,113,133,0.6)] focus-visible:ring-[rgba(251,113,133,0.4)] focus-visible:border-[rgba(251,113,133,0.9)]' : ''
-  return [base, palette, invalid].join(' ')
+const sizeClass = computed(() => {
+  switch (props.size) {
+    case 'sm':
+      return 'px-3 py-2 text-[0.75rem]'
+    case 'lg':
+      return 'px-4 py-3 text-[0.88rem]'
+    default:
+      return 'px-3.5 py-2.5 text-[0.82rem]'
+  }
 })
+
+const variantClass = computed(() => {
+  const alias: Record<ControlVariant, ControlVariant> = {
+    filled: 'filled',
+    outlined: 'outlined',
+    outline: 'outlined',
+    text: 'text'
+  }
+  const key = alias[props.variant] ?? 'outlined'
+  const map: Record<string, string> = {
+    filled: 'bg-[color:var(--md-comp-field-container)] border border-transparent focus-visible:ring-offset-[color:var(--md-comp-field-container)] hover:bg-[color:color-mix(in_srgb,var(--md-comp-field-container) 96%, var(--md-sys-color-surface-tint) 4%)]',
+    outlined: 'bg-transparent border border-[color:var(--md-comp-field-outline)] hover:border-[color:var(--md-sys-color-primary)] focus-visible:ring-offset-[color:var(--md-sys-color-surface)]',
+    text: 'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--md-comp-field-outline)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:var(--md-sys-color-primary)]'
+  }
+  return map[key] ?? map.outlined
+})
+
+const invalidClass = computed(() => props.invalid
+  ? 'border-[color:var(--md-sys-color-error)] focus-visible:ring-[color:var(--md-sys-color-error)] focus-visible:ring-offset-[color:var(--md-sys-color-error-container)]'
+  : '')
+
+const klass = computed(() => [
+  'w-full rounded-[var(--radius-md)] transition-all duration-[var(--transition-short)] text-[color:var(--md-comp-field-on-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--md-comp-focus-ring)]',
+  sizeClass.value,
+  variantClass.value,
+  invalidClass.value
+].join(' '))
 </script>
 
 <template>
   <select
     :value="props.modelValue ?? ''"
+    :data-variant="props.variant"
+    :aria-invalid="props.invalid ? 'true' : 'false'"
     @change="emit('update:modelValue', ($event.target as HTMLSelectElement).value)"
     :class="klass"
   >
@@ -33,5 +65,4 @@ const klass = computed(() => {
     <option v-for="o in props.options" :key="o.value" :value="o.value">{{ o.label }}</option>
     <slot />
   </select>
-  
 </template>

--- a/packages/ui/src/components/AppTagInput.vue
+++ b/packages/ui/src/components/AppTagInput.vue
@@ -2,13 +2,15 @@
 import { ref, watch, computed } from 'vue'
 import AppBadge from './AppBadge.vue'
 import AppIcon from './AppIcon.vue'
+import type { ControlVariant, ControlSize } from '../types'
 
 const props = withDefaults(defineProps<{
   modelValue?: string
   placeholder?: string
-  variant?: 'outline'|'filled'|'ghost'
-  size?: 'sm'|'md'|'lg'
-}>(), { modelValue: '', placeholder: 'Add and press Enter...', variant: 'outline', size: 'md' })
+  variant?: ControlVariant
+  size?: ControlSize
+}>(), { modelValue: '', placeholder: 'Add and press Enter…', variant: 'outlined', size: 'md' })
+
 const emit = defineEmits<{ (e:'update:modelValue', v:string): void }>()
 
 const input = ref('')
@@ -43,36 +45,58 @@ function onKey(e: KeyboardEvent) {
     emit('update:modelValue', valueStr.value)
   }
 }
-const wrapperClass = computed(() => {
-  const size = props.size === 'sm' ? 'px-2 py-1.5 text-[0.68rem]' : props.size === 'lg' ? 'px-3 py-2.5 text-[0.82rem]' : 'px-2.5 py-2 text-[0.75rem]'
-  const base = `flex flex-wrap items-center gap-1 rounded-[var(--radius-sm)] border shadow-[var(--shadow-soft)] ${size}`
-  const palette = props.variant === 'filled'
-    ? 'bg-[color:var(--surface-veil)] border-[color:var(--border)]'
-    : props.variant === 'ghost'
-    ? 'bg-transparent border-transparent focus-within:border-[color:var(--accent)]'
-    : 'bg-[color:var(--surface-translucent)] border-[color:var(--btn-border)]'
-  return [base, palette].join(' ')
+
+const sizeClass = computed(() => {
+  switch (props.size) {
+    case 'sm':
+      return 'px-3 py-2 text-[0.75rem]'
+    case 'lg':
+      return 'px-4 py-3 text-[0.88rem]'
+    default:
+      return 'px-3.5 py-2.5 text-[0.82rem]'
+  }
 })
+
+const variantClass = computed(() => {
+  const alias: Record<ControlVariant, ControlVariant> = {
+    filled: 'filled',
+    outlined: 'outlined',
+    outline: 'outlined',
+    text: 'text'
+  }
+  const key = alias[props.variant] ?? 'outlined'
+  const map: Record<string, string> = {
+    filled: 'bg-[color:var(--md-comp-field-container)] border border-transparent focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-[color:var(--md-comp-field-container)] hover:bg-[color:color-mix(in_srgb,var(--md-comp-field-container) 96%, var(--md-sys-color-surface-tint) 4%)]',
+    outlined: 'bg-transparent border border-[color:var(--md-comp-field-outline)] focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-[color:var(--md-sys-color-surface)] hover:border-[color:var(--md-sys-color-primary)]',
+    text: 'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--md-comp-field-outline)] px-0 bg-transparent focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-0 hover:border-[color:var(--md-sys-color-primary)]'
+  }
+  return map[key] ?? map.outlined
+})
+
+const wrapperClass = computed(() => [
+  'flex flex-wrap items-center gap-1 rounded-[var(--radius-md)] shadow-[var(--shadow-level1)] transition-shadow duration-[var(--transition-short)] focus-within:shadow-[var(--shadow-level2)]',
+  sizeClass.value,
+  variantClass.value
+].join(' '))
 </script>
 
 <template>
   <div :class="wrapperClass">
-    <AppBadge v-for="(t, i) in tags" :key="t" variant="neutral">
+    <AppBadge v-for="(t, i) in tags" :key="t" variant="neutral" size="sm">
       <span>{{ t }}</span>
       <button
         type="button"
-        class="ml-1 inline-flex items-center justify-center rounded-[var(--radius-xs)] p-0.5 text-[color:var(--muted)] transition-colors hover:bg-[color:var(--surface-veil)] hover:text-[color:var(--fg)]"
+        class="ml-1 inline-flex items-center justify-center rounded-[var(--radius-xs)] p-0.5 text-[color:var(--md-sys-color-on-surface-variant)] transition-colors duration-[var(--transition-short)] hover:bg-[color:var(--md-comp-button-ghost-hover-layer)] hover:text-[color:var(--md-sys-color-on-surface)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--md-comp-focus-ring)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--md-sys-color-surface)]"
         @click="removeAt(i)"
       >
-        <AppIcon name="x" />
+        <AppIcon name="x" size="xs" />
       </button>
     </AppBadge>
     <input
       v-model="input"
       :placeholder="props.placeholder"
       @keydown="onKey"
-      class="flex-1 bg-transparent px-2 py-1 text-[color:var(--fg)] placeholder:text-[color:var(--muted)] focus-visible:outline-none"
+      class="flex-1 bg-transparent px-2 py-1 text-[color:var(--md-comp-field-on-surface)] placeholder:text-[color:var(--md-comp-field-placeholder)] focus-visible:outline-none"
     />
   </div>
 </template>
-

--- a/packages/ui/src/components/AppText.vue
+++ b/packages/ui/src/components/AppText.vue
@@ -1,34 +1,63 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import type { Tone, TextSize } from '../types'
 
-type Variant = 'body' | 'muted' | 'caption' | 'mono' | 'small' | 'lead'
-type Tone = 'fg' | 'muted' | 'accent'
-type Size = 'xs' | 'sm' | 'md' | 'lg'
+type Variant = 'body' | 'muted' | 'caption' | 'label' | 'title' | 'display' | 'mono'
 
-const props = withDefaults(defineProps<{
+const props = withDefaults(defineProps<{ 
   as?: keyof HTMLElementTagNameMap
   variant?: Variant
   tone?: Tone
-  size?: Size
+  size?: TextSize
   class?: string
 }>(), { as: 'p', variant: 'body', class: '' })
 
-const map: Record<string, string> = {
-  body: 'text-[color:var(--fg)] leading-relaxed',
-  muted: 'text-[color:var(--muted)] leading-relaxed',
-  caption: 'text-[0.62rem] uppercase tracking-[0.32em] text-[color:var(--muted)]',
-  mono: 'font-mono text-sm text-[color:var(--accent-strong)]',
-  small: 'text-sm text-[color:var(--fg)]',
-  lead: 'text-base text-[color:var(--accent-weak)]',
+const variantMap: Record<Variant, string> = {
+  body: 'text-[color:var(--md-sys-color-on-surface)] leading-relaxed',
+  muted: 'text-[color:var(--md-sys-color-on-surface-variant)] leading-relaxed',
+  caption: 'text-[0.68rem] uppercase tracking-[0.28em] text-[color:var(--md-sys-color-on-surface-variant)]',
+  label: 'text-[0.82rem] uppercase tracking-[0.12em] font-medium text-[color:var(--md-sys-color-on-surface)]',
+  title: 'text-[1.1rem] font-semibold text-[color:var(--md-sys-color-on-surface)]',
+  display: '[font-family:var(--font-display)] text-[1.6rem] font-semibold leading-tight text-[color:var(--md-sys-color-on-surface)]',
+  mono: 'font-mono text-sm text-[color:var(--md-sys-color-on-surface-variant)]'
 }
 
-const toneClass = computed(() => props.tone === 'accent' ? 'text-[color:var(--accent)]' : props.tone === 'muted' ? 'text-[color:var(--muted)]' : props.tone === 'fg' ? 'text-[color:var(--fg)]' : '')
-const sizeClass = computed(() => props.size === 'xs' ? 'text-[0.75rem]' : props.size === 'sm' ? 'text-[0.875rem]' : props.size === 'lg' ? 'text-[1.125rem]' : props.size === 'md' ? 'text-[1rem]' : '')
+const toneClass = computed(() => {
+  switch (props.tone) {
+    case 'accent':
+    case 'primary':
+      return 'text-[color:var(--md-sys-color-primary)]'
+    case 'secondary':
+      return 'text-[color:var(--md-sys-color-secondary)]'
+    case 'muted':
+      return 'text-[color:var(--md-sys-color-on-surface-variant)]'
+    case 'fg':
+      return 'text-[color:var(--md-sys-color-on-surface)]'
+    case 'success':
+      return 'text-[color:var(--md-sys-color-success)]'
+    default:
+      return ''
+  }
+})
+
+const sizeClass = computed(() => {
+  switch (props.size) {
+    case 'xs':
+      return 'text-[0.78rem]'
+    case 'sm':
+      return 'text-[0.9rem]'
+    case 'md':
+      return 'text-[1rem]'
+    case 'lg':
+      return 'text-[1.2rem]'
+    default:
+      return ''
+  }
+})
 </script>
 
 <template>
-  <component :is="props.as" :class="[map[props.variant], sizeClass, toneClass, props.class]">
+  <component :is="props.as" :class="[variantMap[props.variant], sizeClass, toneClass, props.class]">
     <slot />
   </component>
 </template>
-

--- a/packages/ui/src/components/AppTextarea.vue
+++ b/packages/ui/src/components/AppTextarea.vue
@@ -1,26 +1,55 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-const props = withDefaults(defineProps<{
-  modelValue?: string
-  placeholder?: string
-  rows?: number
-  variant?: 'outline' | 'filled' | 'ghost'
-  invalid?: boolean
-  size?: 'sm'|'md'|'lg'
-}>(), { placeholder: '', rows: 3, variant: 'outline', invalid: false, size: 'md' })
-const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
+import type { ControlVariant, ControlSize } from '../types'
 
-const klass = computed(() => {
-  const size = props.size === 'sm' ? 'px-2.5 py-1.5 text-[0.68rem]' : props.size === 'lg' ? 'px-3.5 py-2.5 text-[0.82rem]' : 'px-3 py-2 text-[0.75rem]'
-  const base = `w-full rounded-[var(--radius-sm)] border ${size} transition-all duration-150 text-[color:var(--fg)] placeholder:text-[color:var(--muted)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-1 focus-visible:ring-offset-[color:var(--surface)]`
-  const palette = props.variant === 'filled'
-    ? 'bg-[color:var(--surface-veil)] border-[color:var(--border)]'
-    : props.variant === 'ghost'
-    ? 'bg-transparent border-transparent focus-visible:border-[color:var(--accent)]'
-    : 'bg-[color:var(--surface-translucent)] border-[color:var(--btn-border)]'
-  const invalid = props.invalid ? 'border-[rgba(251,113,133,0.6)] focus-visible:ring-[rgba(251,113,133,0.4)] focus-visible:border-[rgba(251,113,133,0.9)]' : ''
-  return [base, palette, invalid].join(' ')
+const props = withDefaults(defineProps<{
+  modelValue?: string | null
+  placeholder?: string
+  variant?: ControlVariant
+  invalid?: boolean
+  size?: ControlSize
+  rows?: number
+}>(), { placeholder: '', variant: 'outlined', invalid: false, size: 'md', rows: 4 })
+
+const emit = defineEmits<{ (e: 'update:modelValue', v: any): void }>()
+
+const sizeClass = computed(() => {
+  switch (props.size) {
+    case 'sm':
+      return 'px-3 py-2 text-[0.75rem]'
+    case 'lg':
+      return 'px-4 py-3 text-[0.88rem]'
+    default:
+      return 'px-3.5 py-2.5 text-[0.82rem]'
+  }
 })
+
+const variantClass = computed(() => {
+  const alias: Record<ControlVariant, ControlVariant> = {
+    filled: 'filled',
+    outlined: 'outlined',
+    outline: 'outlined',
+    text: 'text'
+  }
+  const key = alias[props.variant] ?? 'outlined'
+  const map: Record<string, string> = {
+    filled: 'bg-[color:var(--md-comp-field-container)] border border-transparent focus-visible:ring-offset-[color:var(--md-comp-field-container)] hover:bg-[color:color-mix(in_srgb,var(--md-comp-field-container) 96%, var(--md-sys-color-surface-tint) 4%)]',
+    outlined: 'bg-transparent border border-[color:var(--md-comp-field-outline)] hover:border-[color:var(--md-sys-color-primary)] focus-visible:ring-offset-[color:var(--md-sys-color-surface)]',
+    text: 'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--md-comp-field-outline)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:var(--md-sys-color-primary)]'
+  }
+  return map[key] ?? map.outlined
+})
+
+const invalidClass = computed(() => props.invalid
+  ? 'border-[color:var(--md-sys-color-error)] focus-visible:ring-[color:var(--md-sys-color-error)] focus-visible:ring-offset-[color:var(--md-sys-color-error-container)]'
+  : '')
+
+const klass = computed(() => [
+  'w-full rounded-[var(--radius-md)] transition-all duration-[var(--transition-short)] text-[color:var(--md-comp-field-on-surface)] placeholder:text-[color:var(--md-comp-field-placeholder)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--md-comp-focus-ring)]',
+  sizeClass.value,
+  variantClass.value,
+  invalidClass.value
+].join(' '))
 </script>
 
 <template>
@@ -28,6 +57,8 @@ const klass = computed(() => {
     :rows="props.rows"
     :placeholder="props.placeholder"
     :value="props.modelValue ?? ''"
+    :data-variant="props.variant"
+    :aria-invalid="props.invalid ? 'true' : 'false'"
     @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
     :class="klass"
   />

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -1,25 +1,40 @@
 // Shared UI types for consumers
 
 // Buttons
-export type ButtonVariant = 'default' | 'primary' | 'secondary' | 'danger' | 'ghost' | 'outline' | 'subtle' | 'accent'
+export type ButtonVariant =
+  | 'filled'
+  | 'tonal'
+  | 'filled-tonal'
+  | 'outlined'
+  | 'text'
+  | 'elevated'
+  | 'surface'
+  | 'ghost'
+  | 'danger'
+  | 'success'
+  | 'default'
+  | 'primary'
+  | 'secondary'
+  | 'accent'
+  | 'outline'
+  | 'subtle'
 export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg'
 
 // Icon buttons share the same variant set; sizes are square
 export type IconButtonSize = ButtonSize
 
 // Form controls
-export type ControlVariant = 'outline' | 'filled' | 'ghost'
+export type ControlVariant = 'filled' | 'outlined' | 'text' | 'outline'
 export type ControlSize = 'sm' | 'md' | 'lg'
 
 // Labels / text tones and sizes
-export type Tone = 'muted' | 'fg' | 'accent'
+export type Tone = 'muted' | 'fg' | 'accent' | 'primary' | 'secondary' | 'success'
 export type TextSize = 'xs' | 'sm' | 'md' | 'lg'
 
 // Icons
 export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'inline'
-export type IconColor = 'default' | 'muted' | 'accent' | 'danger' | 'fg' | 'bg'
+export type IconColor = 'default' | 'muted' | 'accent' | 'danger' | 'fg' | 'bg' | 'primary' | 'success'
 export type IconWeight = 'outline' | 'solid'
 
 // Dropdown
 export type DropdownAlign = 'left' | 'right'
-

--- a/packages/ui/src/utils/motion.ts
+++ b/packages/ui/src/utils/motion.ts
@@ -1,31 +1,71 @@
-// Simple motion presets usable with Vue <Transition>
+const easeOut = 'cubic-bezier(0, 0, 0.2, 1)'
+const easeIn = 'cubic-bezier(0.4, 0, 1, 1)'
+const easeEmphasized = 'cubic-bezier(0.05, 0.7, 0.1, 1)'
 
+// Simple motion presets usable with Vue <Transition>
 export const fadeScale = {
-  enterActiveClass: 'transition ease-out duration-150',
+  enterActiveClass: `transition ${easeOut} duration-[var(--transition-short)]`,
   enterFromClass: 'opacity-0 scale-95',
   enterToClass: 'opacity-100 scale-100',
-  leaveActiveClass: 'transition ease-in duration-100',
+  leaveActiveClass: `transition ${easeIn} duration-[var(--transition-micro)]`,
   leaveFromClass: 'opacity-100 scale-100',
-  leaveToClass: 'opacity-0 scale-95',
+  leaveToClass: 'opacity-0 scale-95'
 }
 
 export const fadeSlideUp = {
-  enterActiveClass: 'transition ease-out duration-150',
-  enterFromClass: 'opacity-0 translate-y-1',
+  enterActiveClass: `transition ${easeOut} duration-[var(--transition-short)]`,
+  enterFromClass: 'opacity-0 translate-y-2',
   enterToClass: 'opacity-100 translate-y-0',
-  leaveActiveClass: 'transition ease-in duration-100',
+  leaveActiveClass: `transition ${easeIn} duration-[var(--transition-micro)]`,
   leaveFromClass: 'opacity-100 translate-y-0',
-  leaveToClass: 'opacity-0 translate-y-1',
+  leaveToClass: 'opacity-0 translate-y-2'
+}
+
+export const expandCollapse = {
+  enterActiveClass: `transition-[max-height,opacity] ${easeEmphasized} duration-[var(--transition-medium)]`,
+  enterFromClass: 'max-h-0 opacity-0',
+  enterToClass: 'max-h-[40rem] opacity-100',
+  leaveActiveClass: `transition-[max-height,opacity] ${easeIn} duration-[var(--transition-short)]`,
+  leaveFromClass: 'max-h-[40rem] opacity-100',
+  leaveToClass: 'max-h-0 opacity-0'
+}
+
+export const fadeSlideRight = {
+  enterActiveClass: `transition ${easeOut} duration-[var(--transition-short)]`,
+  enterFromClass: 'opacity-0 -translate-x-2',
+  enterToClass: 'opacity-100 translate-x-0',
+  leaveActiveClass: `transition ${easeIn} duration-[var(--transition-micro)]`,
+  leaveFromClass: 'opacity-100 translate-x-0',
+  leaveToClass: 'opacity-0 -translate-x-2'
 }
 
 export const listItem = {
-  enterActiveClass: 'transition duration-150 ease-out',
+  enterActiveClass: `transition ${easeOut} duration-[var(--transition-short)]`,
   enterFromClass: 'opacity-0 -translate-y-1',
   enterToClass: 'opacity-100 translate-y-0',
-  leaveActiveClass: 'transition duration-100 ease-in',
+  leaveActiveClass: `transition ${easeIn} duration-[var(--transition-micro)]`,
   leaveFromClass: 'opacity-100 translate-y-0',
-  leaveToClass: 'opacity-0 -translate-y-1',
+  leaveToClass: 'opacity-0 -translate-y-1'
 }
 
-export const listMoveClass = 'transition-transform duration-150';
+export const listMoveClass = 'transition-transform duration-[var(--transition-short)] ease-[cubic-bezier(0.2,0,0,1)]'
 
+export const pop = {
+  enterActiveClass: `transition ${easeEmphasized} duration-[var(--transition-short)]`,
+  enterFromClass: 'opacity-0 scale-90',
+  enterToClass: 'opacity-100 scale-100',
+  leaveActiveClass: `transition ${easeIn} duration-[var(--transition-micro)]`,
+  leaveFromClass: 'opacity-100 scale-100',
+  leaveToClass: 'opacity-0 scale-95'
+}
+
+export const bottomSheet = {
+  enterActiveClass: `transition-transform ${easeEmphasized} duration-[var(--transition-long)]`,
+  enterFromClass: 'translate-y-full',
+  enterToClass: 'translate-y-0',
+  leaveActiveClass: `transition-transform ${easeIn} duration-[var(--transition-medium)]`,
+  leaveFromClass: 'translate-y-0',
+  leaveToClass: 'translate-y-full'
+}
+
+export const shimmerPulse = 'animate-[pulse_1.2s_ease-in-out_infinite]'

--- a/packages/ui/src/utils/variants.ts
+++ b/packages/ui/src/utils/variants.ts
@@ -2,31 +2,125 @@ export function cx(...parts: Array<string | false | null | undefined>) {
   return parts.filter(Boolean).join(' ')
 }
 
-// Button sizes (text buttons)
+const easeStandard = 'cubic-bezier(0.2, 0, 0, 1)'
+
+// Button sizes follow Material 3 specs
 export const btnSizes: Record<string, string> = {
-  xs: 'px-2.5 py-1 text-[0.62rem]',
-  sm: 'px-3 py-1.5 text-[0.68rem]',
-  md: 'px-4 py-2 text-[0.75rem]',
-  lg: 'px-5 py-2.5 text-[0.82rem]',
+  xs: 'h-8 px-3 text-[0.7rem] tracking-[0.08em]',
+  sm: 'h-9 px-3.5 text-[0.75rem] tracking-[0.08em]',
+  md: 'h-10 px-4 text-[0.82rem] tracking-[0.08em]',
+  lg: 'h-11 px-5 text-[0.9rem] tracking-[0.08em]'
 }
 
-// Icon button sizes (square)
+// Icon button sizes (square) retain Material rhythm
 export const iconBtnSizes: Record<string, string> = {
-  xs: 'h-7 w-7',
-  sm: 'h-8 w-8',
-  md: 'h-9 w-9',
-  lg: 'h-10 w-10',
+  xs: 'h-8 w-8',
+  sm: 'h-9 w-9',
+  md: 'h-10 w-10',
+  lg: 'h-11 w-11'
 }
 
-// Button variants palette
+const variantStyles: Record<string, string> = {
+  filled: [
+    'border-transparent',
+    'bg-[color:var(--md-comp-button-filled-container)]',
+    'text-[color:var(--md-comp-button-filled-on-container)]',
+    'shadow-[var(--shadow-level2)]',
+    'hover:bg-[color:var(--md-comp-button-filled-container-hover)]',
+    'active:shadow-[var(--shadow-level1)]',
+    'focus-visible:ring-offset-[color:var(--md-comp-button-filled-container)]',
+    "[--_state-layer-color:color-mix(in_srgb,var(--md-comp-button-filled-on-container) 18%,transparent)]"
+  ].join(' '),
+  tonal: [
+    'border-transparent',
+    'bg-[color:var(--md-comp-button-tonal-container)]',
+    'text-[color:var(--md-comp-button-tonal-on-container)]',
+    'shadow-[var(--shadow-level1)]',
+    'hover:bg-[color:var(--md-comp-button-tonal-container-hover)]',
+    'focus-visible:ring-offset-[color:var(--md-comp-button-tonal-container)]',
+    "[--_state-layer-color:color-mix(in_srgb,var(--md-comp-button-tonal-on-container) 18%,transparent)]"
+  ].join(' '),
+  elevated: [
+    'border-transparent',
+    'bg-[color:var(--md-comp-button-elevated-container)]',
+    'text-[color:var(--md-comp-button-elevated-on-container)]',
+    'shadow-[var(--shadow-level2)]',
+    'hover:bg-[color:var(--md-comp-button-elevated-container-hover)]',
+    'hover:shadow-[var(--shadow-level3)]',
+    'active:shadow-[var(--shadow-level1)]',
+    "[--_state-layer-color:color-mix(in_srgb,var(--md-comp-button-elevated-on-container) 14%,transparent)]"
+  ].join(' '),
+  outlined: [
+    'border-[color:var(--md-comp-button-outlined-outline)]',
+    'bg-transparent',
+    'text-[color:var(--md-comp-button-text-label)]',
+    'hover:bg-[color:var(--md-comp-button-outlined-hover-layer)]',
+    "[--_state-layer-color:color-mix(in_srgb,var(--md-comp-button-text-label) 14%,transparent)]"
+  ].join(' '),
+  text: [
+    'border-transparent',
+    'bg-transparent',
+    'text-[color:var(--md-comp-button-text-label)]',
+    'hover:bg-[color:var(--md-comp-button-text-hover-layer)]',
+    "[--_state-layer-color:color-mix(in_srgb,var(--md-comp-button-text-label) 14%,transparent)]"
+  ].join(' '),
+  ghost: [
+    'border-transparent',
+    'bg-transparent',
+    'text-[color:var(--md-comp-button-ghost-label)]',
+    'hover:bg-[color:var(--md-comp-button-ghost-hover-layer)]',
+    "[--_state-layer-color:color-mix(in_srgb,var(--md-comp-button-ghost-label) 16%,transparent)]"
+  ].join(' '),
+  surface: [
+    'border-[color:var(--md-sys-color-outline-variant)]',
+    'bg-[color:var(--md-sys-color-surface-container-high)]',
+    'text-[color:var(--md-sys-color-on-surface)]',
+    'hover:bg-[color:var(--md-sys-color-surface-container-highest)]',
+    "[--_state-layer-color:color-mix(in_srgb,var(--md-sys-color-on-surface) 12%,transparent)]"
+  ].join(' '),
+  danger: [
+    'border-transparent',
+    'bg-[color:var(--md-comp-button-danger-container)]',
+    'text-[color:var(--md-comp-button-danger-on-container)]',
+    'hover:bg-[color:var(--md-comp-button-danger-container-hover)]',
+    'focus-visible:ring-offset-[color:var(--md-comp-button-danger-container)]',
+    "[--_state-layer-color:color-mix(in_srgb,var(--md-comp-button-danger-on-container) 18%,transparent)]"
+  ].join(' '),
+  success: [
+    'border-transparent',
+    'bg-[color:var(--md-comp-button-success-container)]',
+    'text-[color:var(--md-comp-button-success-on-container)]',
+    'hover:bg-[color:var(--md-comp-button-success-container-hover)]',
+    'focus-visible:ring-offset-[color:var(--md-comp-button-success-container)]',
+    "[--_state-layer-color:color-mix(in_srgb,var(--md-comp-button-success-on-container) 18%,transparent)]"
+  ].join(' ')
+}
+
 export const btnVariants: Record<string, string> = {
-  default: '',
-  primary: 'bg-[color:var(--accent)] text-[color:var(--bg)] border-[color:var(--accent)] shadow-[var(--shadow-button-hover)] hover:shadow-[var(--shadow-button-hover)] focus-visible:ring-[color:var(--accent-strong)]',
-  secondary: 'bg-[color:var(--surface-veil)] text-[color:var(--fg)] border-[color:var(--border)]',
-  danger: 'bg-[#fb7185] text-white border-[#fb7185] shadow-[var(--shadow-button-hover)] focus-visible:ring-[rgba(251,113,133,0.5)]',
-  ghost: 'bg-transparent text-[color:var(--fg)] border-transparent shadow-none hover:border-[color:var(--border)] hover:bg-[color:var(--surface-translucent)] hover:shadow-none focus-visible:ring-[color:var(--accent-weak)]',
-  outline: 'bg-transparent text-[color:var(--fg)] border-[color:var(--border)] shadow-none hover:border-[color:var(--accent)] hover:shadow-none',
-  subtle: 'bg-transparent text-[color:var(--muted)] border-transparent shadow-none hover:text-[color:var(--fg)] hover:border-[color:var(--border)] hover:shadow-none',
+  ...variantStyles,
+  default: variantStyles.elevated,
+  primary: variantStyles.filled,
+  accent: variantStyles.filled,
+  filled: variantStyles.filled,
+  tonal: variantStyles.tonal,
+  secondary: variantStyles.tonal,
+  'filled-tonal': variantStyles.tonal,
+  elevated: variantStyles.elevated,
+  outline: variantStyles.outlined,
+  outlined: variantStyles.outlined,
+  text: variantStyles.text,
+  ghost: variantStyles.ghost,
+  surface: variantStyles.surface,
+  subtle: variantStyles.surface,
+  danger: variantStyles.danger,
+  success: variantStyles.success
 }
 
-export const btnBase = 'inline-flex items-center justify-center gap-2 rounded-[var(--radius-sm)] border border-[color:var(--btn-border)] bg-[color:var(--btn-bg)] text-[color:var(--btn-fg)] font-semibold uppercase tracking-[0.16em] transition-all duration-200 select-none shadow-[var(--shadow-button)] hover:border-[color:var(--accent)] hover:shadow-[var(--shadow-button-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-[color:var(--surface)] active:translate-y-[1px]'
+export const btnBase = [
+  'relative inline-flex items-center justify-center gap-2 overflow-hidden rounded-[var(--radius-md)] border select-none',
+  `font-medium uppercase transition-[box-shadow,transform,background-color,color] duration-[var(--transition-short)] ease-[${easeStandard}]`,
+  'before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:bg-[color:var(--_state-layer-color,transparent)] before:opacity-0 before:transition-opacity before:duration-[var(--transition-short)]',
+  'hover:before:opacity-[var(--md-comp-state-layer-opacity-hover)] focus-visible:before:opacity-[var(--md-comp-state-layer-opacity-focus)] active:before:opacity-[var(--md-comp-state-layer-opacity-pressed)]',
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--md-comp-focus-ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--md-sys-color-surface)]',
+  'active:translate-y-[1px] disabled:pointer-events-none disabled:opacity-60'
+].join(' ')


### PR DESCRIPTION
## Summary
- replace legacy cyberpunk variables with Material 3 palettes, success/error tokens, and updated typography/shape definitions
- refit shared UI components to the new variants, state layers, and hover/focus animations, including button groups, inputs, dropdowns, and badges
- refresh motion presets and README guidance to cover the expanded transition utilities

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d657979a58832f82a1fad5f5b64106