### PR TITLE
Refine Daggerheart builder experience

### DIFF
--- a/apps/daggerheart-statblock-builder/src/components/StatblockPreview.vue
+++ b/apps/daggerheart-statblock-builder/src/components/StatblockPreview.vue
@@ -86,7 +86,7 @@ const hasDetailContent = computed(() => {
 </script>
 
 <template>
-  <AppCard padding="lg" variant="elevated" class="preview-card">
+  <AppCard padding="lg" variant="surface" class="preview-card">
     <header class="preview-header">
       <div>
         <p class="preview-eyebrow">{{ isEnemy ? 'Enemy statblock' : 'Environment statblock' }}</p>
@@ -99,7 +99,7 @@ const hasDetailContent = computed(() => {
       </div>
     </header>
 
-    <AppText v-if="description" variant="lead" class="preview-description">{{ description }}</AppText>
+    <AppText v-if="description" variant="body" size="md" class="preview-description">{{ description }}</AppText>
 
     <div v-if="traits.length" class="preview-traits">
       <AppBadge v-for="trait in traits" :key="trait" variant="neutral">{{ trait }}</AppBadge>

--- a/apps/daggerheart-statblock-builder/src/style.css
+++ b/apps/daggerheart-statblock-builder/src/style.css
@@ -22,17 +22,13 @@ a:hover {
 
 .toolbar {
   position: sticky;
-  top: 1rem;
-  z-index: 25;
+  top: clamp(1.25rem, 6vw, 2.25rem);
+  z-index: 30;
   border-radius: var(--radius-xl);
-  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
-  background: color-mix(in srgb, var(--surface-translucent) 90%, transparent);
-  box-shadow: var(--shadow-card);
-  backdrop-filter: blur(16px);
-}
-
-.toolbar.topbar {
-  margin-top: -1.5rem;
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  background: color-mix(in srgb, var(--surface-translucent) 94%, transparent);
+  box-shadow: var(--shadow-elevated);
+  backdrop-filter: blur(18px);
 }
 
 .print-only {

--- a/packages/ui/src/components/AppButtonGroup.vue
+++ b/packages/ui/src/components/AppButtonGroup.vue
@@ -95,7 +95,7 @@ function itemClass(active: boolean) {
 </script>
 
 <template>
-  <div :class="cx('inline-flex overflow-hidden rounded-[var(--radius-md)] backdrop-blur-sm', containerClass.value)">
+  <div :class="cx('inline-flex overflow-hidden rounded-[var(--radius-md)] backdrop-blur-sm', containerClass)">
     <button
       v-for="opt in props.options"
       :key="opt.value"

--- a/packages/ui/src/components/AppCard.vue
+++ b/packages/ui/src/components/AppCard.vue
@@ -24,7 +24,7 @@ const paddingClass = computed(() => props.padding === 'sm' ? 'p-4' : props.paddi
 </script>
 
 <template>
-  <section :class="cx('rounded-[var(--radius-lg)] transition-shadow duration-[var(--transition-short)] backdrop-blur-sm', variantClass.value, paddingClass.value)">
+  <section :class="cx('rounded-[var(--radius-lg)] transition-shadow duration-[var(--transition-short)] backdrop-blur-sm', variantClass, paddingClass)">
     <header v-if="props.title" class="mb-4">
       <h2 class="font-semibold text-[1.05rem] tracking-[0.04em] text-[color:var(--md-sys-color-on-surface)]">{{ props.title }}</h2>
     </header>


### PR DESCRIPTION
## Summary
- reorganize the statblock builder shell to use shared layout primitives and refreshed hero presentation
- surface tier guidance and workflow tips in dedicated cards alongside the live preview
- adjust shared UI card/button group templates for cleaner template typing and update preview card styling

## Testing
- pnpm --filter daggerheart-statblock-builder build

------
https://chatgpt.com/codex/tasks/task_e_68d65ae84130832fa629b1a495443fe3