### PR TITLE
Refactor Daggerheart App.vue into modular components

### DIFF
--- a/apps/daggerheart-statblock-builder/src/App.vue
+++ b/apps/daggerheart-statblock-builder/src/App.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
-import { AppBadge, AppButton, AppCard, AppCol, AppIconButton, AppRow, AppText } from '@my-monorepo/ui'
-import WizardBuilder from './components/WizardBuilder.vue'
+import { computed, ref } from 'vue'
+import { AppCol, AppRow } from '@my-monorepo/ui'
+import BuilderHero from './components/BuilderHero.vue'
+import BuilderInsights from './components/BuilderInsights.vue'
+import BuilderWizardOverlay from './components/BuilderWizardOverlay.vue'
 import StatblockPreview from './components/StatblockPreview.vue'
 import Toolbar from './components/Toolbar.vue'
 import PrintableStatblock from './components/PrintableStatblock.vue'
@@ -90,28 +92,29 @@ function handleFinish() {
   closeWizard()
 }
 
-watch(
-  () => showWizard.value,
-  (open) => {
-    document.body.style.setProperty('overflow', open ? 'hidden' : '')
-  }
-)
-
-function onKeydown(event: KeyboardEvent) {
-  if (event.key === 'Escape' && showWizard.value) {
-    event.preventDefault()
-    closeWizard()
-  }
+function handleUpdateSbType(value: 'enemy' | 'environment') {
+  sbType.value = value
 }
 
-onMounted(() => {
-  window.addEventListener('keydown', onKeydown)
-})
+function handleUpdateName(value: string) {
+  name.value = value
+}
 
-onBeforeUnmount(() => {
-  window.removeEventListener('keydown', onKeydown)
-  document.body.style.removeProperty('overflow')
-})
+function handleUpdateArchetype(value: string) {
+  archetype.value = value
+}
+
+function handleUpdateTier(value: number | null) {
+  tier.value = value
+}
+
+function handleUpdateDescription(value: string) {
+  description.value = value
+}
+
+function handleUpdateTraits(value: string) {
+  traits.value = value
+}
 </script>
 
 <template>
@@ -119,36 +122,15 @@ onBeforeUnmount(() => {
     <div class="shell-aura" aria-hidden="true" />
 
     <div class="page-container">
-      <AppCard padding="lg" variant="surface" class="hero-card">
-        <div class="hero-grid">
-          <div class="hero-main">
-            <AppBadge size="xs" variant="neutral" class="hero-eyebrow">Currently editing</AppBadge>
-            <div class="hero-title-row">
-              <AppText as="h1" size="lg" class="hero-title">{{ displayName }}</AppText>
-              <AppBadge variant="accent" size="sm">{{ typeLabel }}</AppBadge>
-            </div>
-            <AppText variant="body" size="lg" class="hero-lead">{{ summaryMessage }}</AppText>
-            <AppText variant="muted" size="sm" class="meta-note">
-              Saved automatically — export whenever you're ready using the toolbar.
-            </AppText>
-          </div>
-          <div class="hero-actions">
-            <AppButton size="lg" variant="primary" @click="openWizard">Launch guided builder</AppButton>
-            <AppButton size="lg" variant="surface" @click="resetAll">Start fresh</AppButton>
-          </div>
-        </div>
-
-        <div class="hero-highlights">
-          <div class="highlight-card">
-            <span class="highlight-label">Tier status</span>
-            <span class="highlight-value">{{ tierStatus }}</span>
-          </div>
-          <div v-for="item in highlightedMeta" :key="item.label" class="highlight-card">
-            <span class="highlight-label">{{ item.label }}</span>
-            <span class="highlight-value">{{ item.value }}</span>
-          </div>
-        </div>
-      </AppCard>
+      <BuilderHero
+        :display-name="displayName"
+        :type-label="typeLabel"
+        :summary-message="summaryMessage"
+        :tier-status="tierStatus"
+        :highlighted-meta="highlightedMeta"
+        @open-wizard="openWizard"
+        @reset="resetAll"
+      />
 
       <Toolbar
         class="builder-toolbar"
@@ -163,60 +145,7 @@ onBeforeUnmount(() => {
 
       <AppRow class="main-grid" :cols="3" gap="lg">
         <AppCol :span="2">
-          <AppRow class="insight-grid" :cols="2" gap="lg">
-            <AppCol :span="2">
-              <AppCard padding="lg" variant="surface" class="summary-card">
-                <AppText as="h2" variant="title" class="section-title">Quick summary</AppText>
-                <AppText variant="muted" size="sm" class="section-subtitle">
-                  Use the guided modal to capture every detail. This panel updates as you go.
-                </AppText>
-                <div v-if="summaryMeta.length" class="summary-grid">
-                  <div v-for="item in summaryMeta" :key="item.label" class="summary-item">
-                    <span class="summary-label">{{ item.label }}</span>
-                    <span class="summary-value">{{ item.value }}</span>
-                  </div>
-                </div>
-                <AppText v-else variant="muted" class="empty-state">
-                  No details yet — open the builder to get started.
-                </AppText>
-              </AppCard>
-            </AppCol>
-
-            <AppCol :span="tierCallout ? 1 : 2">
-              <AppCard padding="lg" variant="surface" class="tips-card">
-                <AppText as="h2" variant="title" class="section-title">Workflow tips</AppText>
-                <ul class="tips-list">
-                  <li>
-                    <AppText variant="muted" size="sm">
-                      Step through the wizard to keep vital stats grouped by purpose.
-                    </AppText>
-                  </li>
-                  <li>
-                    <AppText variant="muted" size="sm">
-                      Switch between enemy and environment tiers without losing progress.
-                    </AppText>
-                  </li>
-                  <li>
-                    <AppText variant="muted" size="sm">
-                      Use the glossary from the toolbar whenever you need official wording.
-                    </AppText>
-                  </li>
-                </ul>
-              </AppCard>
-            </AppCol>
-
-            <AppCol v-if="tierCallout" :span="1">
-              <AppCard padding="lg" variant="surface" class="tier-card">
-                <AppBadge size="xs" variant="accent" class="tier-badge">Tier insights</AppBadge>
-                <AppText as="h3" variant="title" class="tier-heading">{{ tierCallout.heading }}</AppText>
-                <AppText variant="muted" size="sm" class="tier-summary">{{ tierCallout.summary }}</AppText>
-                <div class="tier-focus">
-                  <AppBadge size="xs" variant="neutral">{{ typeLabel }} focus</AppBadge>
-                  <AppText variant="body" size="sm">{{ tierCallout.focus }}</AppText>
-                </div>
-              </AppCard>
-            </AppCol>
-          </AppRow>
+          <BuilderInsights :summary-meta="summaryMeta" :tier-callout="tierCallout" :type-label="typeLabel" />
         </AppCol>
 
         <AppCol :span="1" class="preview-column">
@@ -225,40 +154,27 @@ onBeforeUnmount(() => {
       </AppRow>
     </div>
 
-    <Transition name="wizard-fade">
-      <div
-        v-if="showWizard"
-        class="wizard-overlay"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Daggerheart statblock builder"
-        @click.self="closeWizard"
-      >
-        <div class="wizard-dialog">
-          <header class="wizard-header">
-            <div>
-              <p class="eyebrow">Guided builder</p>
-              <h2>{{ displayName }}</h2>
-            </div>
-            <AppIconButton name="x" variant="outline" title="Close builder" @click="closeWizard" />
-          </header>
-          <div class="wizard-body">
-            <WizardBuilder
-              :key="wizardKey"
-              v-model:sbType="sbType"
-              v-model:name="name"
-              v-model:archetype="archetype"
-              v-model:tier="tier"
-              v-model:description="description"
-              v-model:traits="traits"
-              :enemy="enemy"
-              :environment="environment"
-              @finish="handleFinish"
-            />
-          </div>
-        </div>
-      </div>
-    </Transition>
+    <BuilderWizardOverlay
+      :open="showWizard"
+      :display-name="displayName"
+      :wizard-key="wizardKey"
+      :sb-type="sbType"
+      :enemy="enemy"
+      :environment="environment"
+      :name="name"
+      :archetype="archetype"
+      :tier="tier"
+      :description="description"
+      :traits="traits"
+      @update:sbType="handleUpdateSbType"
+      @update:name="handleUpdateName"
+      @update:archetype="handleUpdateArchetype"
+      @update:tier="handleUpdateTier"
+      @update:description="handleUpdateDescription"
+      @update:traits="handleUpdateTraits"
+      @close="closeWizard"
+      @finish="handleFinish"
+    />
 
     <div class="print-only">
       <PrintableStatblock :sbType="sbType" :enemy="enemy" :environment="environment" />
@@ -297,197 +213,8 @@ onBeforeUnmount(() => {
   gap: 1.75rem;
 }
 
-.hero-card {
-  position: relative;
-  overflow: hidden;
-  background: color-mix(in srgb, var(--md-sys-color-surface-container-high) 95%, transparent);
-}
-
-.hero-card::after {
-  content: '';
-  position: absolute;
-  inset: -40% -10% auto;
-  height: 60%;
-  background: radial-gradient(circle at top, color-mix(in srgb, var(--accent) 28%, transparent), transparent 70%);
-  opacity: 0.45;
-  pointer-events: none;
-}
-
-.hero-grid {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.hero-main {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.eyebrow {
-  margin: 0;
-  font-size: 0.7rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--muted) 82%, transparent);
-}
-
-.hero-eyebrow {
-  align-self: flex-start;
-}
-
-.hero-title-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.hero-title {
-  margin: 0;
-  font-size: clamp(2.1rem, 3vw + 1.25rem, 3.25rem);
-  font-weight: 700;
-}
-
-.hero-lead {
-  margin: 0;
-  max-width: 46rem;
-}
-
-.meta-note {
-  margin: 0;
-}
-
-.hero-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  align-items: center;
-}
-
-.hero-highlights {
-  position: relative;
-  margin-top: 1.5rem;
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.highlight-card {
-  padding: 0.85rem 1rem;
-  border-radius: var(--radius-lg);
-  background: color-mix(in srgb, var(--surface-veil) 85%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
-  backdrop-filter: blur(10px);
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.highlight-label {
-  font-size: 0.7rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--muted) 85%, transparent);
-}
-
-.highlight-value {
-  font-weight: 600;
-  font-size: 1rem;
-}
-
 .main-grid {
   align-items: flex-start;
-}
-
-.summary-card {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.section-title {
-  margin: 0;
-}
-
-.section-subtitle {
-  margin: 0;
-}
-
-.summary-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-}
-
-.summary-item {
-  padding: 0.75rem 0.9rem;
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--surface-veil) 82%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.summary-label {
-  font-size: 0.72rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--muted) 83%, transparent);
-}
-
-.summary-value {
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.empty-state {
-  margin: 0;
-}
-
-.tips-card {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.tips-list {
-  margin: 0;
-  padding-left: 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
-}
-
-.tier-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.tier-heading {
-  margin: 0;
-}
-
-.tier-summary {
-  margin: 0;
-}
-
-.tier-focus {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.75rem 0.85rem;
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--surface-veil) 80%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
-}
-
-.tier-focus :deep(p) {
-  margin: 0;
 }
 
 .preview-column {
@@ -496,90 +223,20 @@ onBeforeUnmount(() => {
   align-self: flex-start;
 }
 
-.wizard-overlay {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: clamp(1rem, 4vw, 2.5rem);
-  background: color-mix(in srgb, var(--surface-translucent) 85%, rgba(10, 10, 18, 0.6));
-  backdrop-filter: blur(22px);
-  z-index: 50;
-}
-
-.wizard-dialog {
-  width: min(1120px, 100%);
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-  padding: 1.75rem;
-  border-radius: var(--radius-xl);
-  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
-  background: color-mix(in srgb, var(--surface-translucent) 92%, transparent);
-  box-shadow: var(--shadow-elevated);
-  backdrop-filter: blur(20px);
-}
-
-.wizard-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  padding-bottom: 1rem;
-}
-
-.wizard-body {
-  flex: 1;
-  min-height: 0;
-}
-
-.wizard-body :deep(.wizard-shell) {
-  height: 100%;
-}
-
 .print-only {
   display: none;
-}
-
-.wizard-fade-enter-active,
-.wizard-fade-leave-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-
-.wizard-fade-enter-from,
-.wizard-fade-leave-to {
-  opacity: 0;
-  transform: scale(0.98);
-}
-
-@media (min-width: 980px) {
-  .hero-grid {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: flex-start;
-  }
-
-  .hero-actions {
-    align-items: flex-end;
-  }
 }
 
 @media (max-width: 768px) {
   .preview-column {
     position: static;
   }
-
-  .wizard-dialog {
-    padding: 1.25rem;
-  }
 }
 
 @media print {
   .page-container,
-  .wizard-overlay {
+  .builder-toolbar,
+  :deep(.wizard-overlay) {
     display: none !important;
   }
 

--- a/apps/daggerheart-statblock-builder/src/components/BuilderHero.vue
+++ b/apps/daggerheart-statblock-builder/src/components/BuilderHero.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+import { AppBadge, AppButton, AppCard, AppText } from '@my-monorepo/ui'
+
+type HighlightMeta = { label: string; value: string }
+
+defineProps<{
+  displayName: string
+  typeLabel: string
+  summaryMessage: string
+  tierStatus: string
+  highlightedMeta: HighlightMeta[]
+}>()
+
+const emit = defineEmits<{ (e: 'open-wizard'): void; (e: 'reset'): void }>()
+</script>
+
+<template>
+  <AppCard padding="lg" variant="surface" class="hero-card">
+    <div class="hero-grid">
+      <div class="hero-main">
+        <AppBadge size="xs" variant="neutral" class="hero-eyebrow">Currently editing</AppBadge>
+        <div class="hero-title-row">
+          <AppText as="h1" size="lg" class="hero-title">{{ displayName }}</AppText>
+          <AppBadge variant="accent" size="sm">{{ typeLabel }}</AppBadge>
+        </div>
+        <AppText variant="body" size="lg" class="hero-lead">{{ summaryMessage }}</AppText>
+        <AppText variant="muted" size="sm" class="meta-note">
+          Saved automatically — export whenever you're ready using the toolbar.
+        </AppText>
+      </div>
+      <div class="hero-actions">
+        <AppButton size="lg" variant="primary" @click="emit('open-wizard')">Launch guided builder</AppButton>
+        <AppButton size="lg" variant="surface" @click="emit('reset')">Start fresh</AppButton>
+      </div>
+    </div>
+
+    <div class="hero-highlights">
+      <div class="highlight-card">
+        <span class="highlight-label">Tier status</span>
+        <span class="highlight-value">{{ tierStatus }}</span>
+      </div>
+      <div v-for="item in highlightedMeta" :key="item.label" class="highlight-card">
+        <span class="highlight-label">{{ item.label }}</span>
+        <span class="highlight-value">{{ item.value }}</span>
+      </div>
+    </div>
+  </AppCard>
+</template>
+
+<style scoped>
+.hero-card {
+  position: relative;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--md-sys-color-surface-container-high) 95%, transparent);
+}
+
+.hero-card::after {
+  content: '';
+  position: absolute;
+  inset: -40% -10% auto;
+  height: 60%;
+  background: radial-gradient(circle at top, color-mix(in srgb, var(--accent) 28%, transparent), transparent 70%);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.hero-grid {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.hero-eyebrow {
+  align-self: flex-start;
+}
+
+.hero-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.hero-title {
+  margin: 0;
+  font-size: clamp(2.1rem, 3vw + 1.25rem, 3.25rem);
+  font-weight: 700;
+}
+
+.hero-lead {
+  margin: 0;
+  max-width: 46rem;
+}
+
+.meta-note {
+  margin: 0;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.hero-highlights {
+  position: relative;
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.highlight-card {
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--surface-veil) 85%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.highlight-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
+}
+
+.highlight-value {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+@media (min-width: 980px) {
+  .hero-grid {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  .hero-actions {
+    align-items: flex-end;
+  }
+}
+</style>

--- a/apps/daggerheart-statblock-builder/src/components/BuilderInsights.vue
+++ b/apps/daggerheart-statblock-builder/src/components/BuilderInsights.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { AppBadge, AppCard, AppCol, AppRow, AppText } from '@my-monorepo/ui'
+
+type SummaryItem = { label: string; value: string }
+type TierCallout = { heading: string; summary: string; focus: string } | null
+
+defineProps<{
+  summaryMeta: SummaryItem[]
+  tierCallout: TierCallout
+  typeLabel: string
+}>()
+</script>
+
+<template>
+  <AppRow class="insight-grid" :cols="2" gap="lg">
+    <AppCol :span="2">
+      <AppCard padding="lg" variant="surface" class="summary-card">
+        <AppText as="h2" variant="title" class="section-title">Quick summary</AppText>
+        <AppText variant="muted" size="sm" class="section-subtitle">
+          Use the guided modal to capture every detail. This panel updates as you go.
+        </AppText>
+        <div v-if="summaryMeta.length" class="summary-grid">
+          <div v-for="item in summaryMeta" :key="item.label" class="summary-item">
+            <span class="summary-label">{{ item.label }}</span>
+            <span class="summary-value">{{ item.value }}</span>
+          </div>
+        </div>
+        <AppText v-else variant="muted" class="empty-state">
+          No details yet — open the builder to get started.
+        </AppText>
+      </AppCard>
+    </AppCol>
+
+    <AppCol :span="tierCallout ? 1 : 2">
+      <AppCard padding="lg" variant="surface" class="tips-card">
+        <AppText as="h2" variant="title" class="section-title">Workflow tips</AppText>
+        <ul class="tips-list">
+          <li>
+            <AppText variant="muted" size="sm">
+              Step through the wizard to keep vital stats grouped by purpose.
+            </AppText>
+          </li>
+          <li>
+            <AppText variant="muted" size="sm">
+              Switch between enemy and environment tiers without losing progress.
+            </AppText>
+          </li>
+          <li>
+            <AppText variant="muted" size="sm">
+              Use the glossary from the toolbar whenever you need official wording.
+            </AppText>
+          </li>
+        </ul>
+      </AppCard>
+    </AppCol>
+
+    <AppCol v-if="tierCallout" :span="1">
+      <AppCard padding="lg" variant="surface" class="tier-card">
+        <AppBadge size="xs" variant="accent" class="tier-badge">Tier insights</AppBadge>
+        <AppText as="h3" variant="title" class="tier-heading">{{ tierCallout.heading }}</AppText>
+        <AppText variant="muted" size="sm" class="tier-summary">{{ tierCallout.summary }}</AppText>
+        <div class="tier-focus">
+          <AppBadge size="xs" variant="neutral">{{ typeLabel }} focus</AppBadge>
+          <AppText variant="body" size="sm">{{ tierCallout.focus }}</AppText>
+        </div>
+      </AppCard>
+    </AppCol>
+  </AppRow>
+</template>
+
+<style scoped>
+.insight-grid {
+  width: 100%;
+}
+
+.summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.section-title {
+  margin: 0;
+}
+
+.section-subtitle {
+  margin: 0;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.summary-item {
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-veil) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.summary-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 83%, transparent);
+}
+
+.summary-value {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.empty-state {
+  margin: 0;
+}
+
+.tips-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tips-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.tier-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.tier-heading {
+  margin: 0;
+}
+
+.tier-summary {
+  margin: 0;
+}
+
+.tier-focus {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-veil) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+}
+
+.tier-focus :deep(p) {
+  margin: 0;
+}
+</style>

--- a/apps/daggerheart-statblock-builder/src/components/BuilderWizardOverlay.vue
+++ b/apps/daggerheart-statblock-builder/src/components/BuilderWizardOverlay.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { onBeforeUnmount, watch } from 'vue'
+import { AppIconButton } from '@my-monorepo/ui'
+import WizardBuilder from './WizardBuilder.vue'
+import type { Enemy, Environment } from '../types'
+
+const props = defineProps<{
+  open: boolean
+  displayName: string
+  wizardKey: number
+  sbType: 'enemy' | 'environment'
+  enemy: Enemy
+  environment: Environment
+  name: string
+  archetype: string
+  tier: number | null
+  description: string
+  traits: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'finish'): void
+  (e: 'update:sbType', value: 'enemy' | 'environment'): void
+  (e: 'update:name', value: string): void
+  (e: 'update:archetype', value: string): void
+  (e: 'update:tier', value: number | null): void
+  (e: 'update:description', value: string): void
+  (e: 'update:traits', value: string): void
+}>()
+
+let listening = false
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    emit('close')
+  }
+}
+
+watch(
+  () => props.open,
+  (open) => {
+    document.body.style.setProperty('overflow', open ? 'hidden' : '')
+
+    if (open && !listening) {
+      window.addEventListener('keydown', onKeydown)
+      listening = true
+    }
+
+    if (!open && listening) {
+      window.removeEventListener('keydown', onKeydown)
+      listening = false
+    }
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => {
+  if (listening) {
+    window.removeEventListener('keydown', onKeydown)
+  }
+  document.body.style.removeProperty('overflow')
+})
+</script>
+
+<template>
+  <Transition name="wizard-fade">
+    <div
+      v-if="open"
+      class="wizard-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Daggerheart statblock builder"
+      @click.self="emit('close')"
+    >
+      <div class="wizard-dialog">
+        <header class="wizard-header">
+          <div>
+            <p class="eyebrow">Guided builder</p>
+            <h2>{{ displayName }}</h2>
+          </div>
+          <AppIconButton name="x" variant="outline" title="Close builder" @click="emit('close')" />
+        </header>
+        <div class="wizard-body">
+          <WizardBuilder
+            :key="wizardKey"
+            :sbType="sbType"
+            :enemy="enemy"
+            :environment="environment"
+            :name="name"
+            :archetype="archetype"
+            :tier="tier"
+            :description="description"
+            :traits="traits"
+            @update:sbType="(value) => emit('update:sbType', value)"
+            @update:name="(value) => emit('update:name', value)"
+            @update:archetype="(value) => emit('update:archetype', value)"
+            @update:tier="(value) => emit('update:tier', value)"
+            @update:description="(value) => emit('update:description', value)"
+            @update:traits="(value) => emit('update:traits', value)"
+            @finish="emit('finish')"
+          />
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.wizard-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(1rem, 4vw, 2.5rem);
+  background: color-mix(in srgb, var(--surface-translucent) 85%, rgba(10, 10, 18, 0.6));
+  backdrop-filter: blur(22px);
+  z-index: 50;
+}
+
+.wizard-dialog {
+  width: min(1120px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.75rem;
+  border-radius: var(--radius-xl);
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  background: color-mix(in srgb, var(--surface-translucent) 92%, transparent);
+  box-shadow: var(--shadow-elevated);
+  backdrop-filter: blur(20px);
+}
+
+.wizard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  padding-bottom: 1rem;
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+}
+
+.wizard-body {
+  flex: 1;
+  min-height: 0;
+}
+
+.wizard-body :deep(.wizard-shell) {
+  height: 100%;
+}
+
+.wizard-fade-enter-active,
+.wizard-fade-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.wizard-fade-enter-from,
+.wizard-fade-leave-to {
+  opacity: 0;
+  transform: scale(0.98);
+}
+
+@media (max-width: 768px) {
+  .wizard-dialog {
+    padding: 1.25rem;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- extract the hero callout, insights panel, and wizard overlay into focused components
- simplify App.vue by delegating layout rendering and wizard event handling to the new building blocks
- retain existing styling while moving section-specific styles alongside their components

## Testing
- pnpm --filter daggerheart-statblock-builder build

------
https://chatgpt.com/codex/tasks/task_e_68d65dbd4d68832fa3b78f853b156378