### PR TITLE
feat(daggerheart): add material and apple theme presets

### DIFF
--- a/apps/daggerheart-statblock-builder/package.json
+++ b/apps/daggerheart-statblock-builder/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@my-monorepo/theme": "workspace:*",
     "@my-monorepo/ui": "workspace:*",
+    "@my-monorepo/theme": "workspace:*",
     "vue": "^3.5.18"
   },
   "devDependencies": {

--- a/apps/daggerheart-statblock-builder/src/components/Toolbar.vue
+++ b/apps/daggerheart-statblock-builder/src/components/Toolbar.vue
@@ -4,7 +4,7 @@ import { toJSONBlob, toMarkdown, downloadBlob } from '../lib/exporters'
 import { hasSaved, clear } from '../lib/persist'
 import type { Enemy, Environment } from '../types'
 import type { Theme } from '../lib/theme'
-import { themeOptions } from '@my-monorepo/theme'
+import { themeOptions } from '../lib/theme'
 import { openGlossary } from '../lib/glossaryState'
 import {
   AppButton,
@@ -63,8 +63,12 @@ function openDoc(which: 'srd' | 'license') {
 }
 
 const themeItems = computed(() => [
-  { label: 'System', value: 'system', icon: 'palette' as const },
-  ...themeOptions.map((opt) => ({ label: opt.label, value: opt.value, icon: 'palette' as const }))
+  { label: 'System (match device)', value: 'system', icon: 'palette' as const },
+  ...themeOptions.map((opt) => ({
+    label: `${opt.family === 'material' ? 'Material You' : 'Apple Fluent'} · ${opt.mode === 'light' ? 'Light' : 'Dark'}`,
+    value: opt.value,
+    icon: 'palette' as const
+  }))
 ])
 </script>
 

--- a/apps/daggerheart-statblock-builder/src/lib/theme.ts
+++ b/apps/daggerheart-statblock-builder/src/lib/theme.ts
@@ -1,39 +1,128 @@
-import {
-  applyTheme as applyCoreTheme,
-  readStoredTheme,
-  storeThemePreference,
-  type ThemeName
-} from '@my-monorepo/theme'
+import { themeDefinitions, themeOptions, type ThemeDefinition, type ThemeId } from '../theme/themes'
 
-const LEGACY_THEME_KEY = 'dhsb:theme'
+const THEME_STORAGE_KEY = 'dhsb:theme'
 
-export type Theme = 'system' | ThemeName
+export type Theme = 'system' | ThemeId
 
-function readLegacyTheme(): Theme | null {
+let currentPreference: Theme = 'system'
+let currentRoot: HTMLElement | null = null
+let systemMedia: MediaQueryList | null = null
+let systemListener: ((event: MediaQueryListEvent) => void) | null = null
+
+function getDocumentElement(root?: HTMLElement | null): HTMLElement | null {
+  if (root) return root
+  if (typeof document !== 'undefined' && document?.documentElement) {
+    return document.documentElement as HTMLElement
+  }
+  return null
+}
+
+function setTokens(root: HTMLElement, definition: ThemeDefinition) {
+  for (const [token, value] of Object.entries(definition.tokens)) {
+    root.style.setProperty(`--${token}`, value)
+  }
+  root.style.setProperty('color-scheme', definition.mode)
+}
+
+function cleanupSystemListener() {
+  if (systemMedia && systemListener) {
+    if (typeof systemMedia.removeEventListener === 'function') {
+      systemMedia.removeEventListener('change', systemListener)
+    } else if (typeof systemMedia.removeListener === 'function') {
+      systemMedia.removeListener(systemListener)
+    }
+  }
+  systemMedia = null
+  systemListener = null
+}
+
+function getSystemTheme(): ThemeId {
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    return media.matches ? 'material-dark' : 'material-light'
+  }
+  return 'material-light'
+}
+
+function watchSystemPreference() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+  const media = window.matchMedia('(prefers-color-scheme: dark)')
+  systemMedia = media
+  systemListener = () => {
+    if (currentPreference === 'system' && currentRoot) {
+      applyTheme('system', { root: currentRoot })
+    }
+  }
+  if (typeof media.addEventListener === 'function') {
+    media.addEventListener('change', systemListener)
+  } else if (typeof media.addListener === 'function') {
+    media.addListener(systemListener)
+  }
+}
+
+export interface ApplyThemeOptions {
+  root?: HTMLElement | null
+}
+
+export function applyTheme(theme: Theme, options: ApplyThemeOptions = {}) {
+  const root = getDocumentElement(options.root)
+  if (!root) return theme
+
+  currentPreference = theme
+  currentRoot = root
+
+  let appliedId: ThemeId
+  if (theme === 'system') {
+    appliedId = getSystemTheme()
+    cleanupSystemListener()
+    watchSystemPreference()
+    root.setAttribute('data-theme-preference', 'system')
+  } else {
+    appliedId = theme
+    cleanupSystemListener()
+    root.setAttribute('data-theme-preference', theme)
+  }
+
+  const definition = themeDefinitions[appliedId]
+  root.setAttribute('data-theme', appliedId)
+  root.setAttribute('data-theme-family', definition.family)
+  root.setAttribute('data-theme-mode', definition.mode)
+  setTokens(root, definition)
+
+  return appliedId
+}
+
+function isThemeId(value: string | null | undefined): value is ThemeId {
+  if (!value) return false
+  return value in themeDefinitions
+}
+
+function isTheme(value: string | null | undefined): value is Theme {
+  if (!value) return false
+  if (value === 'system') return true
+  return isThemeId(value)
+}
+
+export function saveTheme(theme: Theme) {
   try {
-    const legacy = localStorage.getItem(LEGACY_THEME_KEY) as Theme | null
-    return legacy ?? null
+    if (typeof window === 'undefined' || !window?.localStorage) return
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+  } catch {}
+}
+
+export function readStoredTheme(): Theme | null {
+  try {
+    if (typeof window === 'undefined' || !window?.localStorage) return null
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY)
+    return isTheme(stored) ? stored : null
   } catch {
     return null
   }
 }
 
 export function getSavedTheme(): Theme {
-  const stored = readStoredTheme()
-  if (stored) return stored
-  return readLegacyTheme() ?? 'system'
+  return readStoredTheme() ?? 'system'
 }
 
-export function saveTheme(theme: Theme) {
-  if (theme === 'system') {
-    storeThemePreference('system')
-  } else {
-    storeThemePreference(theme)
-  }
-  try { localStorage.setItem(LEGACY_THEME_KEY, theme) } catch {}
-}
-
-export function applyTheme(theme: Theme) {
-  applyCoreTheme(theme, { persist: false })
-}
-
+export { themeOptions }
+export type { ThemeId }

--- a/apps/daggerheart-statblock-builder/src/style.css
+++ b/apps/daggerheart-statblock-builder/src/style.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "@my-monorepo/theme/styles.css";
+@import "./theme/base.css";
 
 html, body, #app {
   height: 100%;

--- a/apps/daggerheart-statblock-builder/src/theme/base.css
+++ b/apps/daggerheart-statblock-builder/src/theme/base.css
@@ -1,0 +1,65 @@
+:root {
+  color-scheme: light;
+  --font-sans: 'Inter', 'SF Pro Text', 'SF Pro Display', 'Segoe UI', 'Roboto', sans-serif;
+  --bg: #f7f2fa;
+  --fg: #1c1b1f;
+  --link: #6750a4;
+  --surface: #fffbfe;
+  --surface-veil: rgba(103, 80, 164, 0.08);
+  --surface-translucent: rgba(255, 255, 255, 0.85);
+  --border: rgba(103, 80, 164, 0.18);
+  --muted: #625b71;
+  --accent: #6750a4;
+  --accent-weak: #eaddff;
+  --enemy-accent: #b3261e;
+  --env-accent: #2f6f3d;
+  --md-sys-color-primary: #6750a4;
+  --md-sys-color-secondary: #625b71;
+  --md-sys-color-on-surface: #1c1b1f;
+  --md-sys-color-on-surface-variant: #49454f;
+  --shadow-level1: 0 16px 32px rgba(103, 80, 164, 0.12);
+  --shadow-level2: 0 28px 56px rgba(103, 80, 164, 0.18);
+  --shadow-elevated: 0 32px 60px rgba(103, 80, 164, 0.16);
+  --motion-duration-xs: 120ms;
+  --motion-duration-sm: 160ms;
+  --motion-duration-md: 220ms;
+  --motion-duration-lg: 320ms;
+  --motion-easing-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  --motion-easing-standard: cubic-bezier(0.2, 0, 0.38, 0.9);
+  --motion-easing-decelerate: cubic-bezier(0, 0, 0.2, 1);
+  --motion-easing-accelerate: cubic-bezier(0.4, 0, 1, 1);
+  --motion-easing-emphasized-decelerate: cubic-bezier(0.05, 0.7, 0.1, 1);
+  --motion-easing-emphasized-accelerate: cubic-bezier(0.3, 0, 0.8, 0.15);
+  --radius-md: 0.9rem;
+  --radius-lg: 1.35rem;
+  --radius-xl: 1.9rem;
+  --radius-pill: 999px;
+  --space-sm: 0.75rem;
+  --space-md: 1.25rem;
+  --space-lg: 2.2rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --bg: #141218;
+    --fg: #e6e1e5;
+    --link: #d0bcff;
+    --surface: #1d1b20;
+    --surface-veil: rgba(208, 188, 255, 0.12);
+    --surface-translucent: rgba(29, 27, 32, 0.78);
+    --border: rgba(208, 188, 255, 0.24);
+    --muted: #cac4d0;
+    --accent: #d0bcff;
+    --accent-weak: rgba(208, 188, 255, 0.24);
+    --enemy-accent: #ffb4ab;
+    --env-accent: #8cdc90;
+    --md-sys-color-primary: #d0bcff;
+    --md-sys-color-secondary: #ccc2dc;
+    --md-sys-color-on-surface: #e6e1e5;
+    --md-sys-color-on-surface-variant: #cac4d0;
+    --shadow-level1: 0 16px 32px rgba(3, 0, 24, 0.32);
+    --shadow-level2: 0 28px 56px rgba(3, 0, 24, 0.46);
+    --shadow-elevated: 0 32px 60px rgba(3, 0, 24, 0.36);
+  }
+}

--- a/apps/daggerheart-statblock-builder/src/theme/themes.ts
+++ b/apps/daggerheart-statblock-builder/src/theme/themes.ts
@@ -1,0 +1,183 @@
+export type ThemeId = 'material-light' | 'material-dark' | 'apple-light' | 'apple-dark'
+
+export interface ThemeDefinition {
+  id: ThemeId
+  label: string
+  description: string
+  family: 'material' | 'apple'
+  mode: 'light' | 'dark'
+  accent: string
+  tokens: Record<string, string>
+}
+
+const fontStack = "'Inter', 'SF Pro Text', 'SF Pro Display', 'Segoe UI', 'Roboto', sans-serif"
+
+const sharedTokens = {
+  'motion-duration-xs': '120ms',
+  'motion-duration-sm': '160ms',
+  'motion-duration-md': '220ms',
+  'motion-duration-lg': '320ms',
+  'motion-easing-emphasized': 'cubic-bezier(0.2, 0, 0, 1)',
+  'motion-easing-standard': 'cubic-bezier(0.2, 0, 0.38, 0.9)',
+  'motion-easing-decelerate': 'cubic-bezier(0, 0, 0.2, 1)',
+  'motion-easing-accelerate': 'cubic-bezier(0.4, 0, 1, 1)',
+  'motion-easing-emphasized-decelerate': 'cubic-bezier(0.05, 0.7, 0.1, 1)',
+  'motion-easing-emphasized-accelerate': 'cubic-bezier(0.3, 0, 0.8, 0.15)',
+  'radius-md': '0.9rem',
+  'radius-lg': '1.35rem',
+  'radius-xl': '1.9rem',
+  'radius-pill': '999px',
+  'space-sm': '0.75rem',
+  'space-md': '1.25rem',
+  'space-lg': '2.2rem'
+} as const
+
+const materialLight: ThemeDefinition = {
+  id: 'material-light',
+  label: 'Material You (Light)',
+  description: 'Soft surfaces, expressive primary color, and elevated depth inspired by Material Design 3.',
+  family: 'material',
+  mode: 'light',
+  accent: '#6750A4',
+  tokens: {
+    'font-sans': fontStack,
+    bg: '#f7f2fa',
+    fg: '#1c1b1f',
+    link: '#6750a4',
+    surface: '#fffbfe',
+    'surface-veil': 'rgba(103, 80, 164, 0.08)',
+    'surface-translucent': 'rgba(255, 255, 255, 0.85)',
+    border: 'rgba(103, 80, 164, 0.18)',
+    muted: '#625b71',
+    accent: '#6750a4',
+    'accent-weak': '#eaddff',
+    'enemy-accent': '#b3261e',
+    'env-accent': '#2f6f3d',
+    'md-sys-color-primary': '#6750a4',
+    'md-sys-color-secondary': '#625b71',
+    'md-sys-color-on-surface': '#1c1b1f',
+    'md-sys-color-on-surface-variant': '#49454f',
+    'shadow-level1': '0 16px 32px rgba(103, 80, 164, 0.12)',
+    'shadow-level2': '0 28px 56px rgba(103, 80, 164, 0.18)',
+    'shadow-elevated': '0 32px 60px rgba(103, 80, 164, 0.16)',
+    ...sharedTokens
+  }
+}
+
+const materialDark: ThemeDefinition = {
+  id: 'material-dark',
+  label: 'Material You (Dark)',
+  description: 'Vibrant accents that float above rich tonal surfaces for Material Design 3 in the dark.',
+  family: 'material',
+  mode: 'dark',
+  accent: '#d0bcff',
+  tokens: {
+    'font-sans': fontStack,
+    bg: '#141218',
+    fg: '#e6e1e5',
+    link: '#d0bcff',
+    surface: '#1d1b20',
+    'surface-veil': 'rgba(208, 188, 255, 0.12)',
+    'surface-translucent': 'rgba(29, 27, 32, 0.78)',
+    border: 'rgba(208, 188, 255, 0.24)',
+    muted: '#cac4d0',
+    accent: '#d0bcff',
+    'accent-weak': 'rgba(208, 188, 255, 0.24)',
+    'enemy-accent': '#ffb4ab',
+    'env-accent': '#8cdc90',
+    'md-sys-color-primary': '#d0bcff',
+    'md-sys-color-secondary': '#ccc2dc',
+    'md-sys-color-on-surface': '#e6e1e5',
+    'md-sys-color-on-surface-variant': '#cac4d0',
+    'shadow-level1': '0 16px 32px rgba(3, 0, 24, 0.32)',
+    'shadow-level2': '0 28px 56px rgba(3, 0, 24, 0.46)',
+    'shadow-elevated': '0 32px 60px rgba(3, 0, 24, 0.36)',
+    ...sharedTokens
+  }
+}
+
+const appleLight: ThemeDefinition = {
+  id: 'apple-light',
+  label: 'Apple Fluent (Light)',
+  description: 'Translucent layers, vibrant blues, and refined contrast inspired by the latest Apple design language.',
+  family: 'apple',
+  mode: 'light',
+  accent: '#0a84ff',
+  tokens: {
+    'font-sans': "'SF Pro Text', 'SF Pro Display', 'Inter', 'Helvetica Neue', 'Arial', sans-serif",
+    bg: '#f5f5f7',
+    fg: '#1d1d1f',
+    link: '#0a84ff',
+    surface: '#ffffff',
+    'surface-veil': 'rgba(10, 132, 255, 0.08)',
+    'surface-translucent': 'rgba(255, 255, 255, 0.82)',
+    border: 'rgba(60, 60, 67, 0.18)',
+    muted: 'rgba(60, 60, 67, 0.72)',
+    accent: '#0a84ff',
+    'accent-weak': 'rgba(10, 132, 255, 0.22)',
+    'enemy-accent': '#ff375f',
+    'env-accent': '#30d158',
+    'md-sys-color-primary': '#0a84ff',
+    'md-sys-color-secondary': '#5e5ce6',
+    'md-sys-color-on-surface': '#1d1d1f',
+    'md-sys-color-on-surface-variant': 'rgba(60, 60, 67, 0.64)',
+    'shadow-level1': '0 14px 28px rgba(15, 15, 20, 0.12)',
+    'shadow-level2': '0 22px 44px rgba(15, 15, 20, 0.14)',
+    'shadow-elevated': '0 28px 48px rgba(15, 15, 20, 0.12)',
+    ...sharedTokens,
+    'radius-md': '0.8rem',
+    'radius-lg': '1.1rem',
+    'radius-xl': '1.6rem'
+  }
+}
+
+const appleDark: ThemeDefinition = {
+  id: 'apple-dark',
+  label: 'Apple Fluent (Dark)',
+  description: 'High-contrast typography and luminous color pops for an Apple-style dark appearance.',
+  family: 'apple',
+  mode: 'dark',
+  accent: '#409cff',
+  tokens: {
+    'font-sans': "'SF Pro Text', 'SF Pro Display', 'Inter', 'Helvetica Neue', 'Arial', sans-serif",
+    bg: '#1c1c1e',
+    fg: '#f2f2f7',
+    link: '#409cff',
+    surface: '#2c2c2e',
+    'surface-veil': 'rgba(64, 156, 255, 0.12)',
+    'surface-translucent': 'rgba(44, 44, 46, 0.78)',
+    border: 'rgba(84, 84, 88, 0.42)',
+    muted: 'rgba(235, 235, 245, 0.65)',
+    accent: '#409cff',
+    'accent-weak': 'rgba(64, 156, 255, 0.26)',
+    'enemy-accent': '#ff375f',
+    'env-accent': '#32d74b',
+    'md-sys-color-primary': '#409cff',
+    'md-sys-color-secondary': '#64d2ff',
+    'md-sys-color-on-surface': '#f2f2f7',
+    'md-sys-color-on-surface-variant': 'rgba(235, 235, 245, 0.72)',
+    'shadow-level1': '0 18px 34px rgba(5, 5, 10, 0.42)',
+    'shadow-level2': '0 24px 52px rgba(5, 5, 10, 0.46)',
+    'shadow-elevated': '0 28px 60px rgba(5, 5, 10, 0.38)',
+    ...sharedTokens,
+    'radius-md': '0.8rem',
+    'radius-lg': '1.1rem',
+    'radius-xl': '1.6rem'
+  }
+}
+
+export const themeDefinitions: Record<ThemeId, ThemeDefinition> = {
+  'material-light': materialLight,
+  'material-dark': materialDark,
+  'apple-light': appleLight,
+  'apple-dark': appleDark
+}
+
+export const themeOptions = Object.values(themeDefinitions).map((def) => ({
+  value: def.id,
+  label: def.label,
+  description: def.description,
+  family: def.family,
+  mode: def.mode,
+  accent: def.accent
+}))

--- a/packages/ui/src/utils/motion.ts
+++ b/packages/ui/src/utils/motion.ts
@@ -1,7 +1,6 @@
 const easeStandard = "ease-[var(--motion-easing-standard)]"
 const easeDecelerate = "ease-[var(--motion-easing-decelerate)]"
 const easeAccelerate = "ease-[var(--motion-easing-accelerate)]"
-const easeEmphasized = "ease-[var(--motion-easing-emphasized)]"
 const easeEmphasizedDecelerate = "ease-[var(--motion-easing-emphasized-decelerate)]"
 const easeEmphasizedAccelerate = "ease-[var(--motion-easing-emphasized-accelerate)]"
 


### PR DESCRIPTION
## Summary
- add Material You and Apple Fluent theme definitions with light/dark variants and shared tokens
- update the theme application flow and toolbar selector to use the new presets and system fallback
- layer base CSS overrides and clean up the UI motion util for strict builds

## Testing
- pnpm --filter daggerheart-statblock-builder build

------
https://chatgpt.com/codex/tasks/task_e_68d8021e5374832fb624d795d964dfa3