### PR TITLE
Soften UI outlines with glass tokens

### DIFF
--- a/apps/daggerheart-statblock-builder/src/App.vue
+++ b/apps/daggerheart-statblock-builder/src/App.vue
@@ -213,8 +213,8 @@ function handleUpdateTraits(value: string) {
   gap: 1.9rem;
   background: color-mix(in srgb, var(--surface) 97%, transparent);
   border-radius: 1.9rem;
-  border: 1px solid color-mix(in srgb, var(--border) 22%, transparent);
-  box-shadow: 0 28px 60px rgba(15, 12, 40, 0.18);
+  border: none;
+  box-shadow: var(--glass-shadow-lg), var(--glass-highlight);
   backdrop-filter: blur(22px);
 }
 

--- a/apps/daggerheart-statblock-builder/src/components/AttackEditorList.vue
+++ b/apps/daggerheart-statblock-builder/src/components/AttackEditorList.vue
@@ -119,11 +119,11 @@ function updateAttack(idx: number, patch: Partial<Attack>) {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: color-mix(in srgb, var(--surface-veil) 70%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 24%, transparent);
+  background: var(--glass-surface-soft);
+  border: none;
   border-radius: 1rem;
   padding: 0.9rem 1rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
 }
 
 .header-label {
@@ -144,9 +144,9 @@ function updateAttack(idx: number, patch: Partial<Attack>) {
 .editor-card {
   padding: 1rem 1.1rem;
   border-radius: 1.1rem;
-  background: color-mix(in srgb, var(--surface-veil) 68%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 26%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .stat-grid {

--- a/apps/daggerheart-statblock-builder/src/components/BaseDetailsForm.vue
+++ b/apps/daggerheart-statblock-builder/src/components/BaseDetailsForm.vue
@@ -76,9 +76,9 @@ const emit = defineEmits<{
   gap: var(--space-sm);
   padding: 1.1rem 1.2rem;
   border-radius: 1.1rem;
-  background: color-mix(in srgb, var(--surface-veil) 66%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 26%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .form-section + .form-section {

--- a/apps/daggerheart-statblock-builder/src/components/BuilderHero.vue
+++ b/apps/daggerheart-statblock-builder/src/components/BuilderHero.vue
@@ -154,8 +154,9 @@ const emit = defineEmits<{ (e: 'open-wizard'): void; (e: 'reset'): void }>()
   position: relative;
   padding: 1rem 1.1rem;
   border-radius: var(--radius-lg);
-  border: 1px solid color-mix(in srgb, var(--border) 35%, transparent);
-  background: color-mix(in srgb, var(--surface-veil) 74%, transparent);
+  border: none;
+  background: var(--glass-surface-strong);
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
   backdrop-filter: blur(12px);
   display: flex;
   flex-direction: column;
@@ -166,12 +167,12 @@ const emit = defineEmits<{ (e: 'open-wizard'): void; (e: 'reset'): void }>()
 
 .highlight-card:hover {
   transform: translateY(-2px);
-  box-shadow: var(--shadow-level2);
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .highlight-card.tier {
-  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
-  background: color-mix(in srgb, var(--accent-weak) 36%, transparent);
+  background: color-mix(in srgb, var(--accent-weak) 42%, transparent);
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight), 0 18px 36px rgba(103, 80, 164, 0.25);
 }
 
 .highlight-label {

--- a/apps/daggerheart-statblock-builder/src/components/BuilderInsights.vue
+++ b/apps/daggerheart-statblock-builder/src/components/BuilderInsights.vue
@@ -140,8 +140,9 @@ defineProps<{
 .summary-item {
   padding: 0.85rem 1rem;
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--surface-veil) 72%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 32%, transparent);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
@@ -151,7 +152,7 @@ defineProps<{
 
 .summary-item:hover {
   transform: translateY(-2px);
-  box-shadow: var(--shadow-level2);
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .summary-label {
@@ -188,8 +189,9 @@ defineProps<{
   gap: 0.5rem;
   padding: 0.75rem 0.85rem;
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--surface-veil) 70%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 32%, transparent);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
 }
 
 .tier-focus :deep(p) {

--- a/apps/daggerheart-statblock-builder/src/components/BuilderWizardOverlay.vue
+++ b/apps/daggerheart-statblock-builder/src/components/BuilderWizardOverlay.vue
@@ -130,9 +130,9 @@ onBeforeUnmount(() => {
   gap: 1.35rem;
   padding: 1.9rem;
   border-radius: 2rem;
-  border: 1px solid color-mix(in srgb, var(--border) 24%, transparent);
+  border: none;
   background: color-mix(in srgb, var(--surface) 96%, transparent);
-  box-shadow: 0 32px 70px rgba(12, 10, 40, 0.32);
+  box-shadow: var(--glass-shadow-lg), var(--glass-highlight);
   backdrop-filter: blur(24px);
 }
 
@@ -141,8 +141,19 @@ onBeforeUnmount(() => {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 26%, transparent);
+  position: relative;
+  border-bottom: none;
   padding-bottom: 1.1rem;
+}
+
+.wizard-header::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 0;
+  height: 1px;
+  background: linear-gradient(to right, transparent, color-mix(in srgb, var(--border-soft) 80%, transparent), transparent);
+  opacity: 0.8;
+  pointer-events: none;
 }
 
 .eyebrow {

--- a/apps/daggerheart-statblock-builder/src/components/EnemyAbilitiesForm.vue
+++ b/apps/daggerheart-statblock-builder/src/components/EnemyAbilitiesForm.vue
@@ -56,8 +56,8 @@ const guidance = computed(() => getEnemyTierGuidance(props.tier, props.enemy.ran
   gap: var(--space-sm);
   padding: 1.05rem 1.15rem;
   border-radius: 1.1rem;
-  background: color-mix(in srgb, var(--surface-veil) 66%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 24%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 </style>

--- a/apps/daggerheart-statblock-builder/src/components/EnemyProfileForm.vue
+++ b/apps/daggerheart-statblock-builder/src/components/EnemyProfileForm.vue
@@ -192,9 +192,9 @@ function apply(field: 'difficulty' | 'hp' | 'stress' | 'atkBonus') {
   gap: var(--space-sm);
   padding: 1.1rem 1.2rem;
   border-radius: 1.1rem;
-  background: color-mix(in srgb, var(--surface-veil) 66%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 24%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .form-section + .form-section {

--- a/apps/daggerheart-statblock-builder/src/components/EnvironmentFeaturesForm.vue
+++ b/apps/daggerheart-statblock-builder/src/components/EnvironmentFeaturesForm.vue
@@ -67,9 +67,9 @@ const guidance = computed(() => getEnvironmentTierGuidance(props.tier, props.env
   gap: var(--space-sm);
   padding: 1.05rem 1.15rem;
   border-radius: 1.1rem;
-  background: color-mix(in srgb, var(--surface-veil) 66%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 24%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .field-cluster {

--- a/apps/daggerheart-statblock-builder/src/components/EnvironmentProfileForm.vue
+++ b/apps/daggerheart-statblock-builder/src/components/EnvironmentProfileForm.vue
@@ -142,9 +142,9 @@ function applyDifficulty() {
   gap: var(--space-sm);
   padding: 1.1rem 1.2rem;
   border-radius: 1.1rem;
-  background: color-mix(in srgb, var(--surface-veil) 66%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 24%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .form-section + .form-section {

--- a/apps/daggerheart-statblock-builder/src/components/FeatureEditorList.vue
+++ b/apps/daggerheart-statblock-builder/src/components/FeatureEditorList.vue
@@ -129,11 +129,11 @@ function updateFeature(idx: number, patch: Partial<Feature>) {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: color-mix(in srgb, var(--surface-veil) 70%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 24%, transparent);
+  background: var(--glass-surface-soft);
+  border: none;
   border-radius: 1rem;
   padding: 0.9rem 1rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
 }
 
 .header-label {
@@ -154,9 +154,9 @@ function updateFeature(idx: number, patch: Partial<Feature>) {
 .editor-card {
   padding: 1rem 1.1rem;
   border-radius: 1.1rem;
-  background: color-mix(in srgb, var(--surface-veil) 68%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 26%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);

--- a/apps/daggerheart-statblock-builder/src/components/TierSelectionStep.vue
+++ b/apps/daggerheart-statblock-builder/src/components/TierSelectionStep.vue
@@ -80,9 +80,9 @@ const selectedGuide = computed(() => getTierGuide(props.tier ?? defaultTier))
   gap: var(--space-sm);
   padding: 1.1rem 1.2rem;
   border-radius: 1.1rem;
-  background: color-mix(in srgb, var(--surface-veil) 64%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 24%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .form-section + .form-section {
@@ -101,11 +101,11 @@ const selectedGuide = computed(() => getTierGuide(props.tier ?? defaultTier))
   gap: 1rem;
   padding: 1.15rem 1.2rem;
   border-radius: 1.15rem;
-  background: color-mix(in srgb, var(--surface-veil) 70%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 26%, transparent);
+  background: var(--glass-surface-strong);
+  border: none;
   position: relative;
   isolation: isolate;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .guide-panel::after {

--- a/apps/daggerheart-statblock-builder/src/components/Toolbar.vue
+++ b/apps/daggerheart-statblock-builder/src/components/Toolbar.vue
@@ -156,8 +156,8 @@ const themeItems = computed(() => [
   padding: 0.95rem 1.2rem;
   border-radius: 1.2rem;
   background: linear-gradient(120deg, color-mix(in srgb, var(--surface) 98%, transparent), color-mix(in srgb, var(--surface-veil) 60%, transparent));
-  border: 1px solid color-mix(in srgb, var(--border) 22%, transparent);
-  box-shadow: 0 18px 32px rgba(15, 12, 40, 0.12);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
   backdrop-filter: blur(18px);
 }
 
@@ -170,16 +170,16 @@ const themeItems = computed(() => [
 
 .icon-pill {
   border-radius: 0.9rem;
-  background: color-mix(in srgb, var(--surface-veil) 72%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 26%, transparent);
+  background: var(--glass-surface-strong);
+  border: none;
   padding: 0.5rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
   transition: transform var(--motion-duration-sm) var(--motion-easing-emphasized), box-shadow var(--motion-duration-sm) var(--motion-easing-standard);
 }
 
 .icon-pill:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(15, 12, 40, 0.12);
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .toolbar-button {
@@ -204,15 +204,15 @@ const themeItems = computed(() => [
 :deep(.toolbar-dropdown > button) {
   border-radius: 0.95rem;
   padding: 0.6rem 1rem;
-  border: 1px solid color-mix(in srgb, var(--border) 26%, transparent);
-  background: color-mix(in srgb, var(--surface-veil) 72%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+  border: none;
+  background: var(--glass-surface-strong);
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
   transition: transform var(--motion-duration-sm) var(--motion-easing-emphasized), box-shadow var(--motion-duration-sm) var(--motion-easing-standard);
 }
 
 :deep(.toolbar-dropdown > button:hover) {
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(15, 12, 40, 0.12);
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 :deep(.toolbar-dropdown > button .toolbar-button .label) {

--- a/apps/daggerheart-statblock-builder/src/components/WizardBuilder.vue
+++ b/apps/daggerheart-statblock-builder/src/components/WizardBuilder.vue
@@ -224,8 +224,8 @@ const progress = computed(() => Math.round(((current.value + 1) / steps.value.le
   padding: 1.5rem;
   border-radius: 1.6rem;
   background: linear-gradient(160deg, color-mix(in srgb, var(--surface) 99%, transparent), color-mix(in srgb, var(--surface-veil) 55%, transparent));
-  border: 1px solid color-mix(in srgb, var(--border) 28%, transparent);
-  box-shadow: 0 24px 55px rgba(15, 12, 40, 0.12);
+  border: none;
+  box-shadow: var(--glass-shadow-lg), var(--glass-highlight);
   backdrop-filter: blur(18px);
 }
 
@@ -238,8 +238,8 @@ const progress = computed(() => Math.round(((current.value + 1) / steps.value.le
   padding: 1.4rem;
   background: color-mix(in srgb, var(--surface) 99%, transparent);
   border-radius: 1.25rem;
-  border: 1px solid color-mix(in srgb, var(--border) 24%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55), 0 18px 40px rgba(15, 12, 40, 0.1);
+  border: none;
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
 }
 
 .sidebar-copy {
@@ -282,8 +282,8 @@ const progress = computed(() => Math.round(((current.value + 1) / steps.value.le
 
 .stepper-item {
   width: 100%;
-  border: 1px solid color-mix(in srgb, var(--border) 22%, transparent);
-  background: color-mix(in srgb, var(--surface) 98%, transparent);
+  border: none;
+  background: var(--glass-surface-strong);
   display: flex;
   gap: 0.9rem;
   align-items: flex-start;
@@ -293,26 +293,26 @@ const progress = computed(() => Math.round(((current.value + 1) / steps.value.le
   cursor: pointer;
   transition:
     transform var(--motion-duration-sm) var(--motion-easing-emphasized),
-    border-color var(--motion-duration-sm) var(--motion-easing-standard),
     box-shadow var(--motion-duration-sm) var(--motion-easing-standard),
     background var(--motion-duration-sm) var(--motion-easing-standard);
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
 }
 
 .stepper-item:hover:not(.active) {
   transform: translateX(3px);
-  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
-  box-shadow: 0 12px 24px rgba(15, 12, 40, 0.08);
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
+  background: color-mix(in srgb, var(--surface) 94%, var(--accent) 6%);
 }
 
 .stepper-item.active {
   background: linear-gradient(145deg, color-mix(in srgb, var(--accent) 14%, transparent), color-mix(in srgb, var(--surface) 94%, transparent));
-  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-  box-shadow: 0 18px 32px rgba(15, 12, 40, 0.14);
+  box-shadow: var(--glass-shadow-md), 0 18px 32px rgba(103, 80, 164, 0.22);
   transform: translateX(4px);
 }
 
 .stepper-item.complete {
-  border-color: color-mix(in srgb, var(--accent) 34%, transparent);
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
+  background: color-mix(in srgb, var(--accent-weak) 26%, var(--glass-surface-strong));
 }
 
 .indicator {
@@ -324,16 +324,15 @@ const progress = computed(() => Math.round(((current.value + 1) / steps.value.le
   font-weight: 700;
   font-size: 0.88rem;
   color: color-mix(in srgb, var(--fg) 85%, transparent);
-  background: color-mix(in srgb, var(--surface-veil) 70%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 30%, transparent);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.55);
+  background: var(--glass-surface-soft);
+  border: none;
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
 }
 
 .stepper-item.active .indicator,
 .stepper-item.complete .indicator {
   background: linear-gradient(145deg, color-mix(in srgb, var(--accent) 75%, transparent), color-mix(in srgb, var(--accent) 45%, transparent));
   color: color-mix(in srgb, var(--bg) 96%, transparent);
-  border-color: transparent;
   box-shadow: 0 10px 22px rgba(249, 193, 73, 0.35);
 }
 
@@ -386,9 +385,9 @@ const progress = computed(() => Math.round(((current.value + 1) / steps.value.le
   min-height: 0;
   padding: 1.45rem 1.55rem;
   border-radius: 1.3rem;
-  background: color-mix(in srgb, var(--surface) 99%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border) 26%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55), 0 20px 38px rgba(15, 12, 40, 0.08);
+  background: var(--glass-surface-strong);
+  border: none;
+  box-shadow: var(--glass-shadow-md), var(--glass-highlight);
 }
 
 .progress {
@@ -418,10 +417,10 @@ const progress = computed(() => Math.round(((current.value + 1) / steps.value.le
 }
 
 .review-hint {
-  border: 1px dashed color-mix(in srgb, var(--border) 40%, transparent);
   border-radius: var(--radius-lg);
   padding: 1.25rem;
-  background: color-mix(in srgb, var(--surface-veil) 68%, transparent);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent-weak) 32%, transparent), var(--glass-surface-strong));
+  box-shadow: var(--glass-shadow-sm), var(--glass-highlight);
 }
 
 .review-hint h4 {
@@ -440,8 +439,19 @@ const progress = computed(() => Math.round(((current.value + 1) / steps.value.le
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  border-top: 1px solid color-mix(in srgb, var(--border) 28%, transparent);
+  position: relative;
+  border-top: none;
   padding-top: 1.25rem;
+}
+
+.wizard-nav::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto;
+  height: 1px;
+  background: linear-gradient(to right, transparent, color-mix(in srgb, var(--border-soft) 80%, transparent), transparent);
+  opacity: 0.85;
+  pointer-events: none;
 }
 
 .nav-meta {

--- a/apps/daggerheart-statblock-builder/src/style.css
+++ b/apps/daggerheart-statblock-builder/src/style.css
@@ -25,9 +25,9 @@ a:hover {
   top: clamp(1.25rem, 6vw, 2.25rem);
   z-index: 30;
   border-radius: var(--radius-xl);
-  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  border: none;
   background: color-mix(in srgb, var(--surface-translucent) 94%, transparent);
-  box-shadow: var(--shadow-elevated);
+  box-shadow: var(--shadow-elevated), var(--glass-highlight);
   backdrop-filter: blur(18px);
 }
 

--- a/packages/theme/src/index.css
+++ b/packages/theme/src/index.css
@@ -205,6 +205,12 @@
   --border-soft: rgba(103, 80, 164, 0.12);
   --border-muted: rgba(103, 80, 164, 0.08);
   --border-strong: #79747E;
+  --glass-shadow-sm: 0 12px 28px rgba(32, 24, 64, 0.14);
+  --glass-shadow-md: 0 18px 42px rgba(28, 21, 58, 0.18);
+  --glass-shadow-lg: 0 30px 64px rgba(21, 16, 48, 0.22);
+  --glass-highlight: inset 0 1px 0 rgba(255, 255, 255, 0.42);
+  --glass-surface-soft: color-mix(in srgb, var(--surface-veil) 60%, transparent);
+  --glass-surface-strong: color-mix(in srgb, var(--surface-veil) 72%, transparent);
   --accent: #6750A4;
   --accent-weak: #EADDFF;
   --accent-strong: #21005D;

--- a/packages/ui/src/components/AppBadge.vue
+++ b/packages/ui/src/components/AppBadge.vue
@@ -9,14 +9,14 @@ const sizeMap: Record<'xs'|'sm'|'md', string> = {
 }
 
 const variantMap: Record<string, string> = {
-  surface: 'bg-[color:var(--md-sys-color-surface-container-high)] text-[color:var(--md-sys-color-on-surface)] border-[color:var(--md-sys-color-outline-variant)]',
+  surface: 'bg-[color:var(--surface-translucent)] text-[color:var(--md-sys-color-on-surface)] border-[color:var(--border-muted)] backdrop-blur-sm',
   primary: 'bg-[color:var(--md-sys-color-primary-container)] text-[color:var(--md-sys-color-on-primary-container)] border-[color:var(--md-sys-color-primary)]',
   accent: 'bg-[color:var(--md-sys-color-primary-container)] text-[color:var(--md-sys-color-on-primary-container)] border-[color:var(--md-sys-color-primary)]',
-  neutral: 'bg-[color:var(--md-sys-color-surface-variant)] text-[color:var(--md-sys-color-on-surface-variant)] border-[color:var(--md-sys-color-outline)]',
+  neutral: 'bg-[color:var(--md-sys-color-surface-variant)] text-[color:var(--md-sys-color-on-surface-variant)] border-[color:var(--border)]',
   secondary: 'bg-[color:var(--md-sys-color-secondary-container)] text-[color:var(--md-sys-color-on-secondary-container)] border-[color:var(--md-sys-color-secondary)]',
   danger: 'bg-[color:var(--md-sys-color-error-container)] text-[color:var(--md-sys-color-on-error-container)] border-[color:var(--md-sys-color-error)]',
   success: 'bg-[color:var(--md-sys-color-success-container)] text-[color:var(--md-sys-color-on-success-container)] border-[color:var(--md-sys-color-success)]',
-  default: 'bg-[color:var(--md-sys-color-surface-variant)] text-[color:var(--md-sys-color-on-surface-variant)] border-[color:var(--md-sys-color-outline)]'
+  default: 'bg-[color:var(--md-sys-color-surface-variant)] text-[color:var(--md-sys-color-on-surface-variant)] border-[color:var(--border)]'
 }
 
 const props = withDefaults(defineProps<{
@@ -25,7 +25,7 @@ const props = withDefaults(defineProps<{
 }>(), { variant: 'surface', size: 'sm' })
 
 const klass = computed(() => cx(
-  'inline-flex items-center rounded-[var(--radius-pill)] border font-semibold',
+  'inline-flex items-center rounded-[var(--radius-pill)] border font-semibold shadow-[var(--glass-shadow-sm)]',
   sizeMap[props.size],
   variantMap[props.variant] ?? variantMap.surface
 ))

--- a/packages/ui/src/components/AppButtonGroup.vue
+++ b/packages/ui/src/components/AppButtonGroup.vue
@@ -15,7 +15,7 @@ const sizeClass = computed(() => props.size==='sm' ? 'py-1.5 text-[0.7rem]' : pr
 
 const containerClass = computed(() => normalizeVariant(props.variant) === 'ghost'
   ? 'border-transparent bg-transparent shadow-none'
-  : 'border border-[color:var(--md-sys-color-outline-variant)] bg-[color:var(--md-sys-color-surface-container-high)] shadow-[var(--shadow-level1)]')
+  : 'border border-[color:var(--border-soft)] bg-[color:var(--surface-translucent)] backdrop-blur-sm shadow-[var(--glass-shadow-sm)]')
 
 function normalizeVariant(variant: ButtonVariant): 'filled' | 'tonal' | 'surface' | 'outlined' | 'text' | 'ghost' | 'danger' | 'success' {
   switch (variant) {
@@ -56,7 +56,7 @@ function palette(active: boolean) {
       case 'tonal':
         return 'bg-[color:var(--md-comp-button-tonal-container)] text-[color:var(--md-comp-button-tonal-on-container)] border-[color:var(--md-comp-button-tonal-container)]'
       case 'outlined':
-        return 'bg-[color:var(--md-comp-button-outlined-hover-layer)] text-[color:var(--md-comp-button-text-label)] border-[color:var(--md-comp-button-text-label)]'
+        return 'bg-[color:color-mix(in_srgb,var(--accent) 12%, transparent)] text-[color:var(--md-comp-button-text-label)] border-[color:var(--accent)]'
       case 'ghost':
         return 'bg-[color:var(--md-comp-button-ghost-hover-layer)] text-[color:var(--md-comp-button-ghost-label)] border-transparent'
       case 'danger':
@@ -65,7 +65,7 @@ function palette(active: boolean) {
         return 'bg-[color:var(--md-comp-button-success-container)] text-[color:var(--md-comp-button-success-on-container)] border-[color:var(--md-comp-button-success-container)]'
       case 'surface':
       default:
-        return 'bg-[color:var(--md-sys-color-surface-container-high)] text-[color:var(--md-sys-color-on-surface)] border-[color:var(--md-sys-color-outline-variant)]'
+        return 'bg-[color:var(--surface-translucent)] text-[color:var(--md-sys-color-on-surface)] border-[color:var(--border)] backdrop-blur-sm'
     }
   }
 
@@ -75,7 +75,7 @@ function palette(active: boolean) {
     case 'tonal':
       return 'bg-transparent border-[color:var(--md-comp-button-tonal-container)] text-[color:var(--md-comp-button-tonal-container)] hover:bg-[color:var(--md-comp-button-outlined-hover-layer)]'
     case 'outlined':
-      return 'bg-transparent border-[color:var(--md-comp-button-outlined-outline)] text-[color:var(--md-comp-button-text-label)] hover:bg-[color:var(--md-comp-button-outlined-hover-layer)]'
+      return 'bg-transparent border-[color:var(--border)] text-[color:var(--md-comp-button-text-label)] hover:bg-[color:color-mix(in_srgb,var(--accent) 12%, transparent)]'
     case 'ghost':
       return 'bg-transparent border-transparent text-[color:var(--md-comp-button-ghost-label)] hover:bg-[color:var(--md-comp-button-ghost-hover-layer)]'
     case 'danger':
@@ -84,7 +84,7 @@ function palette(active: boolean) {
       return 'bg-transparent border-[color:var(--md-comp-button-success-container)] text-[color:var(--md-comp-button-success-container)] hover:bg-[color:var(--md-comp-button-outlined-hover-layer)]'
     case 'surface':
     default:
-      return 'bg-transparent border-[color:var(--md-sys-color-outline-variant)] text-[color:var(--md-sys-color-on-surface-variant)] hover:bg-[color:var(--md-comp-button-ghost-hover-layer)]'
+      return 'bg-transparent border-[color:var(--border-muted)] text-[color:var(--md-sys-color-on-surface-variant)] hover:bg-[color:var(--glass-surface-soft)]'
   }
 }
 

--- a/packages/ui/src/components/AppCard.vue
+++ b/packages/ui/src/components/AppCard.vue
@@ -22,19 +22,19 @@ const slots = useSlots()
 const variantClass = computed(() => {
   const map: Record<AppCardVariant, string> = {
     elevated:
-      'bg-[color:var(--md-sys-color-surface-container-low)] text-[color:var(--md-sys-color-on-surface)] border border-transparent shadow-[var(--shadow-level2)]',
+      'bg-[color:var(--surface-translucent)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--border-muted)] backdrop-blur-xl shadow-[var(--glass-shadow-md)]',
     filled:
-      'bg-[color:var(--md-sys-color-surface-container-high)] text-[color:var(--md-sys-color-on-surface)] border border-transparent shadow-none',
+      'bg-[color:var(--surface-panel)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--border-muted)] shadow-[var(--glass-shadow-sm)]',
     outlined:
-      'bg-[color:var(--md-sys-color-surface)] text-[color:var(--md-sys-color-on-surface)] border border-[color:color-mix(in srgb,var(--md-sys-color-outline) 60%,transparent)] shadow-none',
+      'bg-[color:var(--surface-translucent)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--border)] backdrop-blur-xl shadow-[var(--glass-shadow-sm)]',
     surface:
-      'bg-[color:var(--md-sys-color-surface-container)] text-[color:var(--md-sys-color-on-surface)] border border-transparent shadow-[var(--shadow-level1)]',
+      'bg-[color:var(--glass-surface-soft)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--border-soft)] backdrop-blur-xl shadow-[var(--glass-shadow-sm)]',
     ghost:
       'bg-transparent text-[color:var(--md-sys-color-on-surface)] border border-transparent shadow-none',
     tonal:
-      'bg-[color:var(--md-sys-color-surface-container-highest)] text-[color:var(--md-sys-color-on-surface)] border border-transparent shadow-none',
+      'bg-[color:var(--surface-panel)] text-[color:var(--md-sys-color-on-surface)] border border-transparent shadow-none',
     default:
-      'bg-[color:var(--md-sys-color-surface-container-high)] text-[color:var(--md-sys-color-on-surface)] border border-transparent shadow-[var(--shadow-level2)]'
+      'bg-[color:var(--surface-translucent)] text-[color:var(--md-sys-color-on-surface)] border border-[color:var(--border-muted)] backdrop-blur-xl shadow-[var(--glass-shadow-md)]'
   }
 
   return map[props.variant ?? 'elevated'] ?? map.elevated

--- a/packages/ui/src/components/AppDropdown.vue
+++ b/packages/ui/src/components/AppDropdown.vue
@@ -53,7 +53,7 @@ function choose(v: string) {
       :leave-from-class="fadeScale.leaveFromClass"
       :leave-to-class="fadeScale.leaveToClass"
     >
-      <div v-if="open" :class="['absolute z-50 mt-2 min-w-[12rem] overflow-hidden rounded-[1rem] border border-[color:color-mix(in srgb, var(--md-sys-color-outline-variant) 55%, transparent)] bg-[color-mix(in srgb, var(--surface) 98%, transparent)] shadow-[0_18px_32px_rgba(15,12,40,0.16)] backdrop-blur-xl ring-1 ring-[color:color-mix(in srgb, var(--accent) 18%, transparent)]/10', props.align==='right' ? 'right-0' : 'left-0']">
+      <div v-if="open" :class="['absolute z-50 mt-2 min-w-[12rem] overflow-hidden rounded-[1rem] border border-[color:var(--border-soft)] bg-[color-mix(in srgb, var(--surface) 94%, transparent)] shadow-[0_18px_32px_rgba(15,12,40,0.16)] backdrop-blur-xl ring-1 ring-[color:color-mix(in srgb, var(--accent) 18%, transparent)]/10', props.align==='right' ? 'right-0' : 'left-0']">
         <button
           v-for="it in props.items"
           :key="it.value"

--- a/packages/ui/src/components/AppInput.vue
+++ b/packages/ui/src/components/AppInput.vue
@@ -33,9 +33,12 @@ const variantClass = computed(() => {
   }
   const key = alias[props.variant] ?? 'outlined'
   const map: Record<string, string> = {
-    filled: 'bg-[color:var(--md-comp-field-container)] border border-transparent focus-visible:ring-offset-[color:var(--md-comp-field-container)] hover:bg-[color:color-mix(in_srgb,var(--md-comp-field-container) 96%, var(--md-sys-color-surface-tint) 4%)]',
-    outlined: 'bg-transparent border border-[color:var(--md-comp-field-outline)] hover:border-[color:var(--md-sys-color-primary)] focus-visible:ring-offset-[color:var(--md-sys-color-surface)]',
-    text: 'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--md-comp-field-outline)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:var(--md-sys-color-primary)]'
+    filled:
+      'bg-[color:var(--surface-translucent)] border border-[color:var(--border-muted)] backdrop-blur-sm focus-visible:ring-offset-[color:var(--surface-translucent)] hover:border-[color:var(--border)]',
+    outlined:
+      'bg-transparent border border-[color:var(--border)] hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)] focus-visible:ring-offset-[color:var(--surface-translucent)]',
+    text:
+      'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--border-muted)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]'
   }
   return map[key] ?? map.outlined
 })

--- a/packages/ui/src/components/AppSelect.vue
+++ b/packages/ui/src/components/AppSelect.vue
@@ -34,9 +34,12 @@ const variantClass = computed(() => {
   }
   const key = alias[props.variant] ?? 'outlined'
   const map: Record<string, string> = {
-    filled: 'bg-[color:var(--md-comp-field-container)] border border-transparent focus-visible:ring-offset-[color:var(--md-comp-field-container)] hover:bg-[color:color-mix(in_srgb,var(--md-comp-field-container) 96%, var(--md-sys-color-surface-tint) 4%)]',
-    outlined: 'bg-transparent border border-[color:var(--md-comp-field-outline)] hover:border-[color:var(--md-sys-color-primary)] focus-visible:ring-offset-[color:var(--md-sys-color-surface)]',
-    text: 'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--md-comp-field-outline)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:var(--md-sys-color-primary)]'
+    filled:
+      'bg-[color:var(--surface-translucent)] border border-[color:var(--border-muted)] backdrop-blur-sm focus-visible:ring-offset-[color:var(--surface-translucent)] hover:border-[color:var(--border)]',
+    outlined:
+      'bg-transparent border border-[color:var(--border)] hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)] focus-visible:ring-offset-[color:var(--surface-translucent)]',
+    text:
+      'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--border-muted)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]'
   }
   return map[key] ?? map.outlined
 })

--- a/packages/ui/src/components/AppTagInput.vue
+++ b/packages/ui/src/components/AppTagInput.vue
@@ -66,9 +66,12 @@ const variantClass = computed(() => {
   }
   const key = alias[props.variant] ?? 'outlined'
   const map: Record<string, string> = {
-    filled: 'bg-[color:var(--md-comp-field-container)] border border-transparent focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-[color:var(--md-comp-field-container)] hover:bg-[color:color-mix(in_srgb,var(--md-comp-field-container) 96%, var(--md-sys-color-surface-tint) 4%)]',
-    outlined: 'bg-transparent border border-[color:var(--md-comp-field-outline)] focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-[color:var(--md-sys-color-surface)] hover:border-[color:var(--md-sys-color-primary)]',
-    text: 'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--md-comp-field-outline)] px-0 bg-transparent focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-0 hover:border-[color:var(--md-sys-color-primary)]'
+    filled:
+      'bg-[color:var(--surface-translucent)] border border-[color:var(--border-muted)] backdrop-blur-sm focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-[color:var(--surface-translucent)] hover:border-[color:var(--border)]',
+    outlined:
+      'bg-transparent border border-[color:var(--border)] focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-[color:var(--surface-translucent)] hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]',
+    text:
+      'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--border-muted)] px-0 bg-transparent focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-0 hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]'
   }
   return map[key] ?? map.outlined
 })

--- a/packages/ui/src/components/AppTextarea.vue
+++ b/packages/ui/src/components/AppTextarea.vue
@@ -33,9 +33,12 @@ const variantClass = computed(() => {
   }
   const key = alias[props.variant] ?? 'outlined'
   const map: Record<string, string> = {
-    filled: 'bg-[color:var(--md-comp-field-container)] border border-transparent focus-visible:ring-offset-[color:var(--md-comp-field-container)] hover:bg-[color:color-mix(in_srgb,var(--md-comp-field-container) 96%, var(--md-sys-color-surface-tint) 4%)]',
-    outlined: 'bg-transparent border border-[color:var(--md-comp-field-outline)] hover:border-[color:var(--md-sys-color-primary)] focus-visible:ring-offset-[color:var(--md-sys-color-surface)]',
-    text: 'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--md-comp-field-outline)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:var(--md-sys-color-primary)]'
+    filled:
+      'bg-[color:var(--surface-translucent)] border border-[color:var(--border-muted)] backdrop-blur-sm focus-visible:ring-offset-[color:var(--surface-translucent)] hover:border-[color:var(--border)]',
+    outlined:
+      'bg-transparent border border-[color:var(--border)] hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)] focus-visible:ring-offset-[color:var(--surface-translucent)]',
+    text:
+      'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--border-muted)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]'
   }
   return map[key] ?? map.outlined
 })


### PR DESCRIPTION
## Summary
- retune input, select, textarea, and tag entry controls to use translucent surfaces and soft border tokens
- refresh card, badge, button group, and dropdown shells to align with the glass surfaces and remove dark outlines

## Testing
- pnpm --filter daggerheart-statblock-builder build

------
https://chatgpt.com/codex/tasks/task_e_68d814ef22a8832fbacfc02163f9a1d7