### PR TITLE
Refactor Daggerheart layout for Material Design 3

### DIFF
--- a/apps/daggerheart-statblock-builder/src/App.vue
+++ b/apps/daggerheart-statblock-builder/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { AppCol, AppRow } from '@my-monorepo/ui'
+import { AppButton, AppIcon, AppIconButton, fadeScale, fadeSlideUp } from '@my-monorepo/ui'
 import BuilderHero from './components/BuilderHero.vue'
 import BuilderInsights from './components/BuilderInsights.vue'
 import BuilderWizardOverlay from './components/BuilderWizardOverlay.vue'
@@ -79,6 +79,27 @@ const summaryMessage = computed(() => {
   return 'Kick things off by selecting a tier — the guided steps will help you fill in everything that matters.'
 })
 
+const topAppBarSubtitle = computed(() => {
+  const details: string[] = [typeLabel.value]
+
+  if (tier.value != null) details.push(`Tier ${tier.value}`)
+
+  if (isEnemy.value) {
+    if (enemy.rank) details.push(enemy.rank)
+    if (enemy.difficulty != null) details.push(`Difficulty ${enemy.difficulty}`)
+  } else {
+    if (environment.category) details.push(environment.category)
+    if (environment.difficulty != null) details.push(`Difficulty ${environment.difficulty}`)
+  }
+
+  return details.join(' • ')
+})
+
+const heroMotion = fadeSlideUp
+const toolbarMotion = fadeSlideUp
+const panelMotion = fadeSlideUp
+const previewMotion = fadeScale
+
 function openWizard() {
   showWizard.value = true
 }
@@ -115,44 +136,121 @@ function handleUpdateDescription(value: string) {
 function handleUpdateTraits(value: string) {
   traits.value = value
 }
+
+function handlePrint() {
+  window.print()
+}
 </script>
 
 <template>
   <div class="app-shell">
-    <div class="shell-aura" aria-hidden="true" />
-
-    <div class="page-container">
-      <BuilderHero
-        :display-name="displayName"
-        :type-label="typeLabel"
-        :summary-message="summaryMessage"
-        :tier-status="tierStatus"
-        :highlighted-meta="highlightedMeta"
-        @open-wizard="openWizard"
-        @reset="resetAll"
-      />
-
-      <Toolbar
-        class="builder-toolbar"
-        :sbType="sbType"
-        :enemy="enemy"
-        :environment="environment"
-        :theme="theme"
-        @update:theme="setTheme"
-        @reset="resetAll"
-        @load-preset="loadPreset"
-      />
-
-      <AppRow class="main-grid" :cols="3" gap="lg">
-        <AppCol :span="2">
-          <BuilderInsights :summary-meta="summaryMeta" :tier-callout="tierCallout" :type-label="typeLabel" />
-        </AppCol>
-
-        <AppCol :span="1" class="preview-column">
-          <StatblockPreview :sbType="sbType" :enemy="enemy" :environment="environment" />
-        </AppCol>
-      </AppRow>
+    <div class="shell-background" aria-hidden="true">
+      <div class="shell-orb shell-orb--primary" />
+      <div class="shell-orb shell-orb--accent" />
+      <div class="shell-noise" />
     </div>
+
+    <main class="layout-surface" role="main">
+      <header class="top-app-bar" role="banner">
+        <div class="top-app-bar__headline">
+          <span class="top-app-bar__eyebrow">Daggerheart builder</span>
+          <span class="top-app-bar__title">{{ displayName }}</span>
+          <span class="top-app-bar__subtitle">{{ topAppBarSubtitle }}</span>
+        </div>
+
+        <div class="top-app-bar__actions">
+          <AppButton variant="tonal" size="sm" class="top-app-bar__action" @click="openWizard">
+            <AppIcon name="dice" size="sm" />
+            <span>Guided build</span>
+          </AppButton>
+          <AppButton variant="text" size="sm" class="top-app-bar__action" @click="resetAll">
+            <AppIcon name="trash" size="sm" />
+            <span>Reset</span>
+          </AppButton>
+          <AppIconButton
+            class="top-app-bar__icon"
+            name="print"
+            variant="surface"
+            size="sm"
+            aria-label="Print statblock"
+            @click="handlePrint"
+          />
+        </div>
+      </header>
+
+      <section class="layout-stack">
+        <Transition
+          appear
+          :enter-active-class="heroMotion.enterActiveClass"
+          :enter-from-class="heroMotion.enterFromClass"
+          :enter-to-class="heroMotion.enterToClass"
+          :leave-active-class="heroMotion.leaveActiveClass"
+          :leave-from-class="heroMotion.leaveFromClass"
+          :leave-to-class="heroMotion.leaveToClass"
+        >
+          <BuilderHero
+            :display-name="displayName"
+            :type-label="typeLabel"
+            :summary-message="summaryMessage"
+            :tier-status="tierStatus"
+            :highlighted-meta="highlightedMeta"
+            @open-wizard="openWizard"
+            @reset="resetAll"
+          />
+        </Transition>
+
+        <Transition
+          appear
+          :enter-active-class="toolbarMotion.enterActiveClass"
+          :enter-from-class="toolbarMotion.enterFromClass"
+          :enter-to-class="toolbarMotion.enterToClass"
+          :leave-active-class="toolbarMotion.leaveActiveClass"
+          :leave-from-class="toolbarMotion.leaveFromClass"
+          :leave-to-class="toolbarMotion.leaveToClass"
+        >
+          <Toolbar
+            class="builder-toolbar"
+            :sbType="sbType"
+            :enemy="enemy"
+            :environment="environment"
+            :theme="theme"
+            @update:theme="setTheme"
+            @reset="resetAll"
+            @load-preset="loadPreset"
+          />
+        </Transition>
+
+        <div class="layout-panels">
+          <Transition
+            appear
+            :enter-active-class="panelMotion.enterActiveClass"
+            :enter-from-class="panelMotion.enterFromClass"
+            :enter-to-class="panelMotion.enterToClass"
+            :leave-active-class="panelMotion.leaveActiveClass"
+            :leave-from-class="panelMotion.leaveFromClass"
+            :leave-to-class="panelMotion.leaveToClass"
+          >
+            <div class="layout-primary">
+              <BuilderInsights :summary-meta="summaryMeta" :tier-callout="tierCallout" :type-label="typeLabel" />
+            </div>
+          </Transition>
+
+          <Transition
+            appear
+            :enter-active-class="previewMotion.enterActiveClass"
+            :enter-from-class="previewMotion.enterFromClass"
+            :enter-to-class="previewMotion.enterToClass"
+            :leave-active-class="previewMotion.leaveActiveClass"
+            :leave-from-class="previewMotion.leaveFromClass"
+            :leave-to-class="previewMotion.leaveToClass"
+          >
+            <div class="layout-preview">
+              <StatblockPreview :key="sbType" :sbType="sbType" :enemy="enemy" :environment="environment" />
+            </div>
+          </Transition>
+        </div>
+      </section>
+    </main>
 
     <BuilderWizardOverlay
       :open="showWizard"
@@ -187,49 +285,179 @@ function handleUpdateTraits(value: string) {
 .app-shell {
   position: relative;
   min-height: 100vh;
-  padding: clamp(3rem, 8vw, 5rem) 0 5rem;
-  background: radial-gradient(circle at 20% 0%, color-mix(in srgb, var(--accent) 14%, transparent), transparent 55%),
-    radial-gradient(circle at 80% 120%, color-mix(in srgb, var(--md-sys-color-primary) 12%, transparent), transparent 72%),
-    color-mix(in srgb, var(--surface) 96%, transparent);
+  padding: clamp(3rem, 8vw, 5rem) clamp(1.25rem, 5vw, 3rem) clamp(4rem, 7vw, 5.5rem);
+  background: radial-gradient(circle at 20% -10%, color-mix(in srgb, var(--accent) 16%, transparent), transparent 62%),
+    radial-gradient(circle at 90% 120%, color-mix(in srgb, var(--md-sys-color-primary) 18%, transparent), transparent 72%),
+    var(--md-sys-color-surface-container-lowest, color-mix(in srgb, var(--surface) 96%, transparent));
+  color: var(--md-sys-color-on-surface, var(--fg));
+  overflow: hidden;
 }
 
-.shell-aura {
+.shell-background {
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, color-mix(in srgb, var(--accent) 10%, transparent), transparent 65%);
-  opacity: 0.35;
   pointer-events: none;
+  overflow: hidden;
+}
+
+.shell-orb {
+  position: absolute;
+  width: clamp(18rem, 42vw, 32rem);
+  height: clamp(18rem, 42vw, 32rem);
+  border-radius: 50%;
+  opacity: 0.36;
+  transform: translate3d(0, 0, 0);
+  animation: floatAura 18s ease-in-out infinite;
+}
+
+.shell-orb--primary {
+  top: clamp(-12rem, -18vw, -6rem);
+  right: clamp(-6rem, -10vw, -1rem);
+  background: radial-gradient(circle, color-mix(in srgb, var(--md-sys-color-secondary) 34%, transparent), transparent 70%);
   mix-blend-mode: screen;
 }
 
-.page-container {
+.shell-orb--accent {
+  bottom: clamp(-10rem, -16vw, -4rem);
+  left: clamp(-12rem, -14vw, -6rem);
+  animation-delay: -6s;
+  background: radial-gradient(circle, color-mix(in srgb, var(--accent) 42%, transparent), transparent 68%);
+  mix-blend-mode: screen;
+}
+
+.shell-noise {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+      120deg,
+      color-mix(in srgb, var(--md-sys-color-surface-container-high, var(--surface)) 12%, transparent),
+      transparent 65%
+    ),
+    radial-gradient(circle at 16% 28%, rgba(255, 255, 255, 0.12), transparent 54%);
+  opacity: 0.28;
+  mix-blend-mode: lighten;
+}
+
+.layout-surface {
   position: relative;
   z-index: 1;
   margin: 0 auto;
-  max-width: 1200px;
-  padding: clamp(1.25rem, 6vw, 2.75rem);
+  max-width: 1180px;
+  width: min(100%, 1180px);
+  padding: clamp(1.5rem, 4vw, 2.75rem);
+  border-radius: 2rem;
+  background: color-mix(in srgb, var(--md-sys-color-surface-container-highest, var(--surface)) 90%, transparent);
+  box-shadow: 0 24px 60px rgba(20, 12, 58, 0.2),
+    0 0 0 1px color-mix(in srgb, var(--surface-outline, rgba(40, 35, 70, 0.26)) 28%, transparent);
+  backdrop-filter: blur(26px);
   display: flex;
   flex-direction: column;
-  gap: 1.9rem;
-  background: color-mix(in srgb, var(--surface) 97%, transparent);
-  border-radius: 1.9rem;
-  border: none;
-  box-shadow: var(--glass-shadow-lg), var(--glass-highlight);
-  backdrop-filter: blur(22px);
+  gap: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.top-app-bar {
+  position: sticky;
+  top: clamp(1.5rem, 5vw, 2.75rem);
+  z-index: 4;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(1.2rem, 3vw, 2rem);
+  padding: clamp(0.75rem, 2vw, 1.25rem) clamp(0.9rem, 2vw, 1.4rem);
+  border-radius: 1.6rem;
+  background: color-mix(in srgb, var(--md-sys-color-surface-container-high, var(--surface-translucent)) 92%, transparent);
+  box-shadow: 0 18px 40px rgba(16, 10, 50, 0.18),
+    0 0 0 1px color-mix(in srgb, var(--md-sys-color-outline-variant, transparent) 40%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.top-app-bar__headline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.top-app-bar__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--md-sys-color-on-surface-variant, var(--muted)) 85%, transparent);
+}
+
+.top-app-bar__title {
+  font-size: clamp(1.4rem, 1.4vw + 1rem, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--md-sys-color-on-surface, var(--fg));
+}
+
+.top-app-bar__subtitle {
+  font-size: 0.95rem;
+  color: color-mix(in srgb, var(--md-sys-color-on-surface-variant, var(--muted)) 92%, transparent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.top-app-bar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.top-app-bar__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+.top-app-bar__action :deep(.app-icon) {
+  margin-left: -0.1rem;
+}
+
+.top-app-bar__icon {
+  border-radius: 0.9rem;
+  box-shadow: 0 10px 24px rgba(24, 16, 60, 0.18);
+}
+
+.layout-stack {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.6rem, 3vw, 2.3rem);
 }
 
 .builder-toolbar {
-  margin-top: -0.3rem;
-}
-
-.main-grid {
-  align-items: flex-start;
-  gap: var(--space-lg);
-}
-
-.preview-column {
   position: sticky;
-  top: 2rem;
+  top: clamp(6.5rem, 11vw, 7.5rem);
+  z-index: 3;
+}
+
+.builder-toolbar :deep(.toolbar-card) {
+  border-radius: 1.35rem;
+  background: color-mix(in srgb, var(--md-sys-color-surface-container-high, var(--surface-translucent)) 94%, transparent);
+  box-shadow: 0 16px 38px rgba(18, 12, 54, 0.18), var(--glass-highlight);
+}
+
+.layout-panels {
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  align-items: start;
+}
+
+.layout-primary {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.2rem, 2vw, 1.8rem);
+}
+
+.layout-preview {
+  position: sticky;
+  top: clamp(7rem, 12vw, 8.5rem);
   align-self: flex-start;
 }
 
@@ -237,27 +465,87 @@ function handleUpdateTraits(value: string) {
   display: none;
 }
 
-@media (max-width: 960px) {
-  .page-container {
-    border-radius: 1.4rem;
-    box-shadow: 0 22px 48px rgba(15, 12, 40, 0.16);
-    padding: clamp(1rem, 5vw, 2rem);
+@media (max-width: 1200px) {
+  .layout-surface {
+    width: min(100%, 1020px);
+  }
+}
+
+@media (max-width: 1024px) {
+  .top-app-bar {
+    flex-direction: column;
+    align-items: stretch;
+    position: static;
   }
 
-  .preview-column {
-    position: static;
+  .top-app-bar__subtitle {
+    white-space: normal;
+  }
+
+  .top-app-bar__actions {
+    justify-content: flex-start;
+  }
+
+  .builder-toolbar {
+    position: relative;
+    top: 0;
+  }
+
+  .layout-panels {
+    grid-template-columns: 1fr;
+  }
+
+  .layout-preview {
+    position: relative;
+    top: 0;
+  }
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    padding: clamp(2rem, 10vw, 3rem) clamp(1rem, 4vw, 1.5rem);
+  }
+
+  .layout-surface {
+    padding: clamp(1.1rem, 6vw, 1.75rem);
+    border-radius: 1.35rem;
+    box-shadow: 0 18px 48px rgba(14, 10, 44, 0.18);
   }
 }
 
 @media print {
-  .page-container,
+  .layout-surface,
+  .top-app-bar,
   .builder-toolbar,
+  .shell-background,
   :deep(.wizard-overlay) {
     display: none !important;
   }
 
   .print-only {
     display: block !important;
+  }
+}
+
+@keyframes floatAura {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(0, -1.5rem, 0) scale(1.05);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .shell-orb {
+    animation: none;
+  }
+
+  .top-app-bar,
+  .builder-toolbar,
+  .layout-surface {
+    backdrop-filter: none;
   }
 }
 </style>

--- a/apps/daggerheart-statblock-builder/src/style.css
+++ b/apps/daggerheart-statblock-builder/src/style.css
@@ -8,8 +8,9 @@ html, body, #app {
 body {
   margin: 0;
   font-family: var(--font-sans);
-  background: var(--bg);
-  color: var(--fg);
+  background: var(--md-sys-color-surface-container-lowest, var(--bg));
+  color: var(--md-sys-color-on-background, var(--fg));
+  transition: background-color 220ms ease, color 220ms ease;
 }
 
 a {
@@ -22,12 +23,12 @@ a:hover {
 
 .toolbar {
   position: sticky;
-  top: clamp(1.25rem, 6vw, 2.25rem);
+  top: clamp(6rem, 11vw, 7rem);
   z-index: 30;
   border-radius: var(--radius-xl);
   border: none;
-  background: color-mix(in srgb, var(--surface-translucent) 94%, transparent);
-  box-shadow: var(--shadow-elevated), var(--glass-highlight);
+  background: color-mix(in srgb, var(--md-sys-color-surface-container-high, var(--surface-translucent)) 94%, transparent);
+  box-shadow: 0 18px 40px rgba(18, 12, 54, 0.18), var(--glass-highlight);
   backdrop-filter: blur(18px);
 }
 
@@ -39,7 +40,7 @@ a:hover {
   border-left: 6px solid var(--accent);
   padding-left: 12px;
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--surface-translucent) 94%, transparent);
+  background: color-mix(in srgb, var(--md-sys-color-surface-container-highest, var(--surface-translucent)) 92%, transparent);
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 


### PR DESCRIPTION
## Summary
- reimagine the statblock builder shell with a Material 3 top app bar, animated background, and motion-enhanced content transitions
- reorganize insights and preview areas into responsive panels with sticky preview positioning and contextual quick actions
- refresh global body and toolbar styling to lean on Material tokens for color, elevation, and animation polish

## Testing
- pnpm --filter daggerheart-statblock-builder build


------
https://chatgpt.com/codex/tasks/task_e_68d821b5bf0c832fb028787d80897b2b