### PR TITLE
refactor(ui): centralize control class utilities

### DIFF
--- a/packages/ui/src/components/AppInput.vue
+++ b/packages/ui/src/components/AppInput.vue
@@ -1,6 +1,12 @@
 ﻿<script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { ControlVariant, ControlSize } from '../types'
+import {
+  BASE_CONTROL_VARIANT_CLASS,
+  INVALID_CONTROL_CLASS,
+  controlSizeClass,
+  normalizeControlVariant
+} from '../utils/control'
 
 const props = withDefaults(defineProps<{
   modelValue?: string | number | null
@@ -13,39 +19,13 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{ (e: 'update:modelValue', v: any): void }>()
 
-const sizeClass = computed(() => {
-  switch (props.size) {
-    case 'sm':
-      return 'px-3 py-2 text-[0.75rem]'
-    case 'lg':
-      return 'px-4 py-3 text-[0.88rem]'
-    default:
-      return 'px-3.5 py-2.5 text-[0.82rem]'
-  }
-})
+const sizeClass = computed(() => controlSizeClass(props.size))
 
-const variantClass = computed(() => {
-  const alias: Record<ControlVariant, ControlVariant> = {
-    filled: 'filled',
-    outlined: 'outlined',
-    outline: 'outlined',
-    text: 'text'
-  }
-  const key = alias[props.variant] ?? 'outlined'
-  const map: Record<string, string> = {
-    filled:
-      'bg-[color:var(--surface-translucent)] border border-[color:var(--border-muted)] backdrop-blur-sm focus-visible:ring-offset-[color:var(--surface-translucent)] hover:border-[color:var(--border)]',
-    outlined:
-      'bg-transparent border border-[color:var(--border)] hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)] focus-visible:ring-offset-[color:var(--surface-translucent)]',
-    text:
-      'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--border-muted)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]'
-  }
-  return map[key] ?? map.outlined
-})
+const normalizedVariant = computed(() => normalizeControlVariant(props.variant, 'outlined'))
 
-const invalidClass = computed(() => props.invalid
-  ? 'border-[color:var(--md-sys-color-error)] focus-visible:ring-[color:var(--md-sys-color-error)] focus-visible:ring-offset-[color:var(--md-sys-color-error-container)]'
-  : '')
+const variantClass = computed(() => BASE_CONTROL_VARIANT_CLASS[normalizedVariant.value])
+
+const invalidClass = computed(() => (props.invalid ? INVALID_CONTROL_CLASS : ''))
 
 const klass = computed(() => [
   'w-full rounded-[var(--radius-md)] transition-all duration-[var(--motion-duration-sm)] text-[color:var(--md-comp-field-on-surface)] placeholder:text-[color:var(--md-comp-field-placeholder)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--md-comp-focus-ring)]',

--- a/packages/ui/src/components/AppSelect.vue
+++ b/packages/ui/src/components/AppSelect.vue
@@ -1,6 +1,12 @@
 ﻿<script setup lang="ts">
 import { computed } from 'vue'
 import type { ControlVariant, ControlSize } from '../types'
+import {
+  BASE_CONTROL_VARIANT_CLASS,
+  INVALID_CONTROL_CLASS,
+  controlSizeClass,
+  normalizeControlVariant
+} from '../utils/control'
 
 type Option = { label: string; value: string }
 
@@ -14,39 +20,13 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{ (e: 'update:modelValue', v: string): void }>()
 
-const sizeClass = computed(() => {
-  switch (props.size) {
-    case 'sm':
-      return 'px-3 py-2 text-[0.75rem]'
-    case 'lg':
-      return 'px-4 py-3 text-[0.88rem]'
-    default:
-      return 'px-3.5 py-2.5 text-[0.82rem]'
-  }
-})
+const sizeClass = computed(() => controlSizeClass(props.size))
 
-const variantClass = computed(() => {
-  const alias: Record<ControlVariant, ControlVariant> = {
-    filled: 'filled',
-    outlined: 'outlined',
-    outline: 'outlined',
-    text: 'text'
-  }
-  const key = alias[props.variant] ?? 'outlined'
-  const map: Record<string, string> = {
-    filled:
-      'bg-[color:var(--surface-translucent)] border border-[color:var(--border-muted)] backdrop-blur-sm focus-visible:ring-offset-[color:var(--surface-translucent)] hover:border-[color:var(--border)]',
-    outlined:
-      'bg-transparent border border-[color:var(--border)] hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)] focus-visible:ring-offset-[color:var(--surface-translucent)]',
-    text:
-      'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--border-muted)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]'
-  }
-  return map[key] ?? map.outlined
-})
+const normalizedVariant = computed(() => normalizeControlVariant(props.variant, 'filled'))
 
-const invalidClass = computed(() => props.invalid
-  ? 'border-[color:var(--md-sys-color-error)] focus-visible:ring-[color:var(--md-sys-color-error)] focus-visible:ring-offset-[color:var(--md-sys-color-error-container)]'
-  : '')
+const variantClass = computed(() => BASE_CONTROL_VARIANT_CLASS[normalizedVariant.value])
+
+const invalidClass = computed(() => (props.invalid ? INVALID_CONTROL_CLASS : ''))
 
 const klass = computed(() => [
   'w-full rounded-[var(--radius-md)] transition-all duration-[var(--motion-duration-sm)] text-[color:var(--md-comp-field-on-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--md-comp-focus-ring)]',

--- a/packages/ui/src/components/AppTagInput.vue
+++ b/packages/ui/src/components/AppTagInput.vue
@@ -3,6 +3,11 @@ import { ref, watch, computed } from 'vue'
 import AppBadge from './AppBadge.vue'
 import AppIcon from './AppIcon.vue'
 import type { ControlVariant, ControlSize } from '../types'
+import {
+  controlSizeClass,
+  normalizeControlVariant,
+  type NormalizedControlVariant
+} from '../utils/control'
 
 const props = withDefaults(defineProps<{
   modelValue?: string
@@ -46,26 +51,12 @@ function onKey(e: KeyboardEvent) {
   }
 }
 
-const sizeClass = computed(() => {
-  switch (props.size) {
-    case 'sm':
-      return 'px-3 py-2 text-[0.75rem]'
-    case 'lg':
-      return 'px-4 py-3 text-[0.88rem]'
-    default:
-      return 'px-3.5 py-2.5 text-[0.82rem]'
-  }
-})
+const sizeClass = computed(() => controlSizeClass(props.size))
+
+const normalizedVariant = computed<NormalizedControlVariant>(() => normalizeControlVariant(props.variant, 'outlined'))
 
 const variantClass = computed(() => {
-  const alias: Record<ControlVariant, ControlVariant> = {
-    filled: 'filled',
-    outlined: 'outlined',
-    outline: 'outlined',
-    text: 'text'
-  }
-  const key = alias[props.variant] ?? 'outlined'
-  const map: Record<string, string> = {
+  const map: Record<NormalizedControlVariant, string> = {
     filled:
       'bg-[color:var(--surface-translucent)] border border-[color:var(--border-muted)] backdrop-blur-sm focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-[color:var(--surface-translucent)] hover:border-[color:var(--border)]',
     outlined:
@@ -73,7 +64,7 @@ const variantClass = computed(() => {
     text:
       'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--border-muted)] px-0 bg-transparent focus-within:ring-2 focus-within:ring-[color:var(--md-comp-focus-ring)] focus-within:ring-offset-0 hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]'
   }
-  return map[key] ?? map.outlined
+  return map[normalizedVariant.value]
 })
 
 const wrapperClass = computed(() => [

--- a/packages/ui/src/components/AppTextarea.vue
+++ b/packages/ui/src/components/AppTextarea.vue
@@ -1,6 +1,12 @@
 ﻿<script setup lang="ts">
 import { computed } from 'vue'
 import type { ControlVariant, ControlSize } from '../types'
+import {
+  BASE_CONTROL_VARIANT_CLASS,
+  INVALID_CONTROL_CLASS,
+  controlSizeClass,
+  normalizeControlVariant
+} from '../utils/control'
 
 const props = withDefaults(defineProps<{
   modelValue?: string | null
@@ -13,39 +19,13 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{ (e: 'update:modelValue', v: any): void }>()
 
-const sizeClass = computed(() => {
-  switch (props.size) {
-    case 'sm':
-      return 'px-3 py-2 text-[0.75rem]'
-    case 'lg':
-      return 'px-4 py-3 text-[0.88rem]'
-    default:
-      return 'px-3.5 py-2.5 text-[0.82rem]'
-  }
-})
+const sizeClass = computed(() => controlSizeClass(props.size))
 
-const variantClass = computed(() => {
-  const alias: Record<ControlVariant, ControlVariant> = {
-    filled: 'filled',
-    outlined: 'outlined',
-    outline: 'outlined',
-    text: 'text'
-  }
-  const key = alias[props.variant] ?? 'outlined'
-  const map: Record<string, string> = {
-    filled:
-      'bg-[color:var(--surface-translucent)] border border-[color:var(--border-muted)] backdrop-blur-sm focus-visible:ring-offset-[color:var(--surface-translucent)] hover:border-[color:var(--border)]',
-    outlined:
-      'bg-transparent border border-[color:var(--border)] hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)] focus-visible:ring-offset-[color:var(--surface-translucent)]',
-    text:
-      'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--border-muted)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]'
-  }
-  return map[key] ?? map.outlined
-})
+const normalizedVariant = computed(() => normalizeControlVariant(props.variant, 'filled'))
 
-const invalidClass = computed(() => props.invalid
-  ? 'border-[color:var(--md-sys-color-error)] focus-visible:ring-[color:var(--md-sys-color-error)] focus-visible:ring-offset-[color:var(--md-sys-color-error-container)]'
-  : '')
+const variantClass = computed(() => BASE_CONTROL_VARIANT_CLASS[normalizedVariant.value])
+
+const invalidClass = computed(() => (props.invalid ? INVALID_CONTROL_CLASS : ''))
 
 const klass = computed(() => [
   'w-full rounded-[var(--radius-md)] transition-all duration-[var(--motion-duration-sm)] text-[color:var(--md-comp-field-on-surface)] placeholder:text-[color:var(--md-comp-field-placeholder)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--md-comp-focus-ring)]',

--- a/packages/ui/src/utils/control.ts
+++ b/packages/ui/src/utils/control.ts
@@ -1,0 +1,39 @@
+import type { ControlSize, ControlVariant } from '../types'
+
+export type NormalizedControlVariant = 'filled' | 'outlined' | 'text'
+
+const CONTROL_SIZE_CLASS: Record<ControlSize, string> = {
+  sm: 'px-3 py-2 text-[0.75rem]',
+  md: 'px-3.5 py-2.5 text-[0.82rem]',
+  lg: 'px-4 py-3 text-[0.88rem]'
+}
+
+const CONTROL_VARIANT_ALIAS: Record<ControlVariant, NormalizedControlVariant> = {
+  filled: 'filled',
+  outlined: 'outlined',
+  outline: 'outlined',
+  text: 'text'
+}
+
+export const BASE_CONTROL_VARIANT_CLASS: Record<NormalizedControlVariant, string> = {
+  filled:
+    'bg-[color:var(--surface-translucent)] border border-[color:var(--border-muted)] backdrop-blur-sm focus-visible:ring-offset-[color:var(--surface-translucent)] hover:border-[color:var(--border)]',
+  outlined:
+    'bg-transparent border border-[color:var(--border)] hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)] focus-visible:ring-offset-[color:var(--surface-translucent)]',
+  text:
+    'rounded-b-none border-x-0 border-t-0 border-b border-[color:var(--border-muted)] px-0 bg-transparent focus-visible:ring-offset-0 hover:border-[color:color-mix(in_srgb,var(--accent) 55%, transparent)]'
+}
+
+export const INVALID_CONTROL_CLASS =
+  'border-[color:var(--md-sys-color-error)] focus-visible:ring-[color:var(--md-sys-color-error)] focus-visible:ring-offset-[color:var(--md-sys-color-error-container)]'
+
+export function controlSizeClass(size: ControlSize | undefined): string {
+  return CONTROL_SIZE_CLASS[size ?? 'md']
+}
+
+export function normalizeControlVariant(
+  variant: ControlVariant | undefined,
+  fallback: NormalizedControlVariant = 'outlined'
+): NormalizedControlVariant {
+  return variant ? CONTROL_VARIANT_ALIAS[variant] ?? fallback : fallback
+}


### PR DESCRIPTION
## Summary
- add shared utilities for control sizing, variant normalization, and invalid styling
- refactor AppInput, AppSelect, AppTextarea, and AppTagInput to consume the shared helpers and reduce duplication

## Testing
- pnpm -r lint *(fails: None of the selected packages has a "lint" script)*

------
https://chatgpt.com/codex/tasks/task_e_68d8777b7b14832fa9a5f9cb7971ab17