### PR TITLE
feat: refresh daggerheart mobile layout

### DIFF
--- a/apps/daggerheart-statblock-builder/src/composables/useClientPlatform.ts
+++ b/apps/daggerheart-statblock-builder/src/composables/useClientPlatform.ts
@@ -1,0 +1,27 @@
+import { computed, onMounted, ref } from 'vue'
+
+export function useClientPlatform() {
+  const isBrowser = ref(false)
+  const isMobileBrowser = ref(false)
+
+  onMounted(() => {
+    isBrowser.value = typeof window !== 'undefined'
+    if (!isBrowser.value) return
+
+    const userAgent = window.navigator?.userAgent ?? ''
+    const platform = window.navigator?.platform ?? ''
+    const mobileRegex = /android|iphone|ipad|ipod|iemobile|mobile|blackberry|webos|windows phone/i
+    const appleMobilePlatforms = ['iPhone', 'iPad', 'iPod']
+
+    const matchesMobile = mobileRegex.test(userAgent) || appleMobilePlatforms.includes(platform)
+    isMobileBrowser.value = matchesMobile
+  })
+
+  const isDesktopBrowser = computed(() => isBrowser.value && !isMobileBrowser.value)
+
+  return {
+    isBrowser: computed(() => isBrowser.value),
+    isMobileBrowser: computed(() => isMobileBrowser.value),
+    isDesktopBrowser,
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@my-monorepo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@my-monorepo/ui-platform':
+        specifier: workspace:*
+        version: link:../../packages/ui-platform
       vue:
         specifier: ^3.5.18
         version: 3.5.21(typescript@5.8.3)
@@ -63,6 +66,9 @@ importers:
       '@my-monorepo/theme':
         specifier: workspace:*
         version: link:../../packages/theme
+      '@my-monorepo/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       minisearch:
         specifier: ^7.1.0
         version: 7.2.0
@@ -91,6 +97,9 @@ importers:
       '@my-monorepo/theme':
         specifier: workspace:*
         version: link:../../packages/theme
+      '@my-monorepo/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       mapbox-gl:
         specifier: ^3.9.0
         version: 3.15.0
@@ -140,6 +149,9 @@ importers:
       '@my-monorepo/theme':
         specifier: workspace:*
         version: link:../../packages/theme
+      '@my-monorepo/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       mapbox-gl:
         specifier: ^3.9.0
         version: 3.15.0
@@ -182,6 +194,15 @@ importers:
       '@my-monorepo/design-tokens':
         specifier: workspace:*
         version: link:../design-tokens
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.21(typescript@5.8.3)
+
+  packages/ui-platform:
+    dependencies:
+      '@my-monorepo/ui':
+        specifier: workspace:*
+        version: link:../ui
       vue:
         specifier: ^3.5.0
         version: 3.5.21(typescript@5.8.3)


### PR DESCRIPTION
## Summary
- add an expressive Material 3 mobile experience with a dedicated top bar, stacked cards, and refreshed navigation
- introduce a reusable client platform composable to detect browser vs mobile browser contexts and expose device classes
- update styling to harmonize new mobile surfaces while preserving the existing desktop layout

## Testing
- pnpm --filter daggerheart-statblock-builder build

------
https://chatgpt.com/codex/tasks/task_e_68d9a05d2ffc832f996c89279d468291