### PR TITLE
feat: add advanced layout controls to DM screen

### DIFF
--- a/apps/daggerheart-dm-screen/src/components/DMToolbar.vue
+++ b/apps/daggerheart-dm-screen/src/components/DMToolbar.vue
@@ -4,11 +4,16 @@ const props = defineProps<{
   subtitle: string;
   pinnedCount: number;
   totalWidgets: number;
+  fullBleed: boolean;
+  fullscreen: boolean;
+  phoneLayout: boolean;
 }>();
 
 const emit = defineEmits<{
   (e: 'reset'): void;
   (e: 'cascade'): void;
+  (e: 'toggle-full-bleed'): void;
+  (e: 'toggle-fullscreen'): void;
 }>();
 </script>
 
@@ -30,8 +35,25 @@ const emit = defineEmits<{
         <span class="label">Pinned</span>
         <span class="value">{{ pinnedCount }}</span>
       </div>
+      <div v-if="props.phoneLayout" class="layout-pill">Phone layout</div>
     </div>
     <div class="actions">
+      <button
+        type="button"
+        class="ghost"
+        :aria-pressed="props.fullBleed"
+        @click="emit('toggle-full-bleed')"
+      >
+        {{ props.fullBleed ? 'Standard Window' : 'Full Window' }}
+      </button>
+      <button
+        type="button"
+        class="ghost"
+        :aria-pressed="props.fullscreen"
+        @click="emit('toggle-fullscreen')"
+      >
+        {{ props.fullscreen ? 'Exit Fullscreen' : 'Go Fullscreen' }}
+      </button>
       <button type="button" class="ghost" @click="emit('cascade')">Cascade Layout</button>
       <button type="button" class="primary" @click="emit('reset')">Reset Board</button>
     </div>
@@ -108,9 +130,21 @@ const emit = defineEmits<{
   font-variant-numeric: tabular-nums;
 }
 
+.layout-pill {
+  align-self: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(118, 174, 255, 0.35);
+  background: rgba(12, 21, 33, 0.6);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .actions {
   display: flex;
   gap: 12px;
+  flex-wrap: wrap;
 }
 
 button {
@@ -133,6 +167,11 @@ button.ghost {
   color: #e6f1ff;
 }
 
+.ghost[aria-pressed='true'] {
+  background: rgba(118, 174, 255, 0.25);
+  border-color: rgba(118, 174, 255, 0.65);
+}
+
 button.primary {
   background: linear-gradient(135deg, rgba(118, 174, 255, 0.9), rgba(94, 219, 255, 0.65));
   color: #041220;
@@ -152,6 +191,16 @@ button:hover {
   .metrics,
   .actions {
     justify-self: start;
+  }
+}
+
+@media (max-width: 640px) {
+  .actions {
+    width: 100%;
+  }
+
+  .actions button {
+    flex: 1 1 48%;
   }
 }
 </style>

--- a/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
+++ b/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
@@ -20,23 +20,27 @@ const componentMap: Record<string, Component> = {
 
 const props = defineProps<{
   widgets: WidgetState[];
+  disableInteractions?: boolean;
 }>();
 
 const emit = defineEmits<{
   (e: 'update:position', payload: { id: string; x: number; y: number }): void;
+  (e: 'update:size', payload: { id: string; width: number; height: number }): void;
   (e: 'focus', id: string): void;
   (e: 'toggle-pin', id: string): void;
 }>();
 </script>
 
 <template>
-  <section class="board" aria-label="Daggerheart control board">
+  <section class="board" :class="{ 'board--mobile': props.disableInteractions }" aria-label="Daggerheart control board">
     <div class="grid-surface" aria-hidden="true"></div>
     <DraggableWidget
       v-for="widget in props.widgets"
       :key="widget.id"
       :widget="widget"
+      :disable-interactions="props.disableInteractions"
       @dragging="(payload) => emit('update:position', payload)"
+      @resizing="(payload) => emit('update:size', payload)"
       @focus="emit('focus', widget.id)"
       @toggle-pin="emit('toggle-pin', widget.id)"
     >
@@ -56,6 +60,14 @@ const emit = defineEmits<{
   padding: 32px;
 }
 
+.board--mobile {
+  min-height: 0;
+  padding: 20px 16px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 .grid-surface {
   position: absolute;
   inset: 0;
@@ -64,5 +76,24 @@ const emit = defineEmits<{
   background-size: 120px 120px;
   opacity: 0.4;
   pointer-events: none;
+}
+
+@media (max-width: 900px) {
+  .board {
+    padding: 28px;
+    min-height: 640px;
+  }
+}
+
+@media (max-width: 720px) {
+  .board {
+    border-radius: 24px;
+    border-width: 1px;
+  }
+
+  .grid-surface {
+    opacity: 0.25;
+    background-size: 80px 80px;
+  }
 }
 </style>

--- a/apps/daggerheart-dm-screen/src/data/widgets.ts
+++ b/apps/daggerheart-dm-screen/src/data/widgets.ts
@@ -21,7 +21,7 @@ export function createInitialWidgets(): WidgetState[] {
       icon: '⏳',
       accent: 'linear-gradient(135deg, rgba(255, 138, 92, 0.6), rgba(255, 90, 90, 0.4))',
       description: 'Track initiative, rounds, and spotlight moments.',
-      position: { x: 48, y: 132 },
+      position: { x: 40, y: 120 },
       size: { width: 400, height: 360 },
       component: 'EncounterTimeline',
       zIndex: baseZ
@@ -32,7 +32,7 @@ export function createInitialWidgets(): WidgetState[] {
       icon: '💠',
       accent: 'linear-gradient(135deg, rgba(86, 196, 255, 0.6), rgba(86, 132, 255, 0.4))',
       description: 'Manage the party\'s shared resources.',
-      position: { x: 500, y: 120 },
+      position: { x: 520, y: 120 },
       size: { width: 320, height: 280 },
       component: 'MomentumTracker',
       zIndex: baseZ - 1
@@ -43,7 +43,7 @@ export function createInitialWidgets(): WidgetState[] {
       icon: '📖',
       accent: 'linear-gradient(135deg, rgba(168, 255, 120, 0.55), rgba(65, 211, 168, 0.35))',
       description: 'Daggerheart conditions at a glance.',
-      position: { x: 880, y: 140 },
+      position: { x: 880, y: 160 },
       size: { width: 320, height: 340 },
       component: 'ConditionsQuickRef',
       zIndex: baseZ - 2
@@ -54,7 +54,7 @@ export function createInitialWidgets(): WidgetState[] {
       icon: '📚',
       accent: 'linear-gradient(135deg, rgba(255, 216, 102, 0.6), rgba(255, 164, 90, 0.35))',
       description: 'Domains, damage, boons, and consequences.',
-      position: { x: 104, y: 520 },
+      position: { x: 120, y: 520 },
       size: { width: 440, height: 320 },
       component: 'SRDLibrary',
       zIndex: baseZ - 3
@@ -65,7 +65,7 @@ export function createInitialWidgets(): WidgetState[] {
       icon: '🎲',
       accent: 'linear-gradient(135deg, rgba(255, 120, 221, 0.55), rgba(162, 92, 255, 0.35))',
       description: 'Generate rolls and improv prompts.',
-      position: { x: 588, y: 456 },
+      position: { x: 600, y: 440 },
       size: { width: 360, height: 320 },
       component: 'DiceOracle',
       zIndex: baseZ - 4
@@ -76,7 +76,7 @@ export function createInitialWidgets(): WidgetState[] {
       icon: '🕸️',
       accent: 'linear-gradient(135deg, rgba(92, 255, 208, 0.55), rgba(92, 164, 255, 0.35))',
       description: 'NPCs, looming dangers, and treasure sparks.',
-      position: { x: 964, y: 488 },
+      position: { x: 960, y: 480 },
       size: { width: 360, height: 340 },
       component: 'ThreatsAndHooks',
       zIndex: baseZ - 5

--- a/apps/daggerheart-dm-screen/vite.config.ts
+++ b/apps/daggerheart-dm-screen/vite.config.ts
@@ -3,6 +3,9 @@ import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
   plugins: [vue()],
+  server: {
+    host: '0.0.0.0'
+  },
   build: {
     sourcemap: true
   }


### PR DESCRIPTION
## Summary
- add layout controls for full-window and fullscreen modes plus responsive phone layout detection
- enable grid-snapped dragging and resizing for widgets with updated defaults and toolbar affordances
- expose the dev server on the local network for easier multi-device access

## Testing
- `pnpm --filter daggerheart-dm-screen build` *(fails: vue-tsc not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9af3942d0832f8212d35f0b6d7371