### PR TITLE
Add persistence and management for custom widgets

### DIFF
--- a/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
+++ b/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
@@ -9,7 +9,7 @@ import DiceOracle from './widgets/DiceOracle.vue';
 import ThreatsAndHooks from './widgets/ThreatsAndHooks.vue';
 import CustomWidgetLibrary from './widgets/CustomWidgetLibrary.vue';
 import CustomWidget from './widgets/CustomWidget.vue';
-import type { CreateWidgetPayload, WidgetState } from '../types';
+import type { CreateWidgetPayload, CustomWidgetConfig, UpdateWidgetPayload, WidgetState } from '../types';
 
 const componentMap: Record<string, Component> = {
   EncounterTimeline,
@@ -33,11 +33,18 @@ const emit = defineEmits<{
   (e: 'focus', id: string): void;
   (e: 'toggle-pin', id: string): void;
   (e: 'create-widget', payload: CreateWidgetPayload): void;
+  (e: 'update-config', payload: { id: string; config: CustomWidgetConfig }): void;
+  (e: 'update-widget', payload: UpdateWidgetPayload): void;
+  (e: 'delete-widget', id: string): void;
 }>();
 
 function getWidgetProps(widget: WidgetState) {
   if (widget.component === 'CustomWidget') {
-    return { config: widget.config };
+    return { config: widget.config, widgetId: widget.id };
+  }
+  if (widget.component === 'CustomWidgetLibrary') {
+    const customWidgets = props.widgets.filter((item) => item.component === 'CustomWidget');
+    return { customWidgets };
   }
   return {};
 }
@@ -60,6 +67,9 @@ function getWidgetProps(widget: WidgetState) {
         :is="componentMap[widget.component] ?? componentMap.EncounterTimeline"
         v-bind="getWidgetProps(widget)"
         @create-widget="(payload) => emit('create-widget', payload)"
+        @update-config="(payload) => emit('update-config', payload)"
+        @update-widget="(payload) => emit('update-widget', payload)"
+        @delete-widget="(id) => emit('delete-widget', id)"
       />
     </DraggableWidget>
   </section>

--- a/apps/daggerheart-dm-screen/src/components/widgets/CustomWidget.vue
+++ b/apps/daggerheart-dm-screen/src/components/widgets/CustomWidget.vue
@@ -10,7 +10,11 @@ import type {
   CustomWidgetConfig
 } from '../../types';
 
-const props = defineProps<{ config?: CustomWidgetConfig }>();
+const props = defineProps<{ config?: CustomWidgetConfig; widgetId: string }>();
+
+const emit = defineEmits<{
+  (e: 'update-config', payload: { id: string; config: CustomWidgetConfig }): void;
+}>();
 
 const checklistItems = ref<CustomChecklistItem[]>([]);
 const trackerTracks = ref<CustomTrackerTrack[]>([]);
@@ -65,16 +69,30 @@ watch(
 );
 
 function toggleChecklistItem(index: number) {
+  if (props.config?.type !== 'checklist') {
+    return;
+  }
   const next = [...checklistItems.value];
   const target = next[index];
   if (!target) {
     return;
   }
   next[index] = { ...target, complete: !target.complete };
-  checklistItems.value = next;
+  const updatedItems = next.map((item) => ({ ...item }));
+  checklistItems.value = updatedItems;
+  emit('update-config', {
+    id: props.widgetId,
+    config: {
+      type: 'checklist',
+      items: updatedItems
+    }
+  });
 }
 
 function adjustTrack(index: number, delta: number) {
+  if (props.config?.type !== 'tracker') {
+    return;
+  }
   const next = [...trackerTracks.value];
   const target = next[index];
   if (!target) {
@@ -85,7 +103,15 @@ function adjustTrack(index: number, delta: number) {
     current: Math.min(Math.max(target.current + delta, 0), Math.max(target.max, 0))
   };
   next[index] = updated;
-  trackerTracks.value = next;
+  const updatedTracks = next.map((track) => ({ ...track }));
+  trackerTracks.value = updatedTracks;
+  emit('update-config', {
+    id: props.widgetId,
+    config: {
+      type: 'tracker',
+      tracks: updatedTracks
+    }
+  });
 }
 </script>
 

--- a/apps/daggerheart-dm-screen/src/types.ts
+++ b/apps/daggerheart-dm-screen/src/types.ts
@@ -76,3 +76,5 @@ export interface CreateWidgetPayload {
   size: WidgetSize;
   config?: CustomWidgetConfig;
 }
+
+export type UpdateWidgetPayload = CreateWidgetPayload & { id: string };


### PR DESCRIPTION
## Summary
- persist the DM screen widget layout to localStorage and restore it on load while keeping reset behaviour intact
- extend the custom widget library to edit or delete existing cards and reuse their configurations
- push checklist and tracker interactions back into shared widget config so runtime changes persist across sessions

## Testing
- pnpm --filter daggerheart-dm-screen build *(fails: vue-tsc binary missing in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b717babc832fb17df15ce943799a