### PR TITLE
Fix DM screen widget event handler typings

### DIFF
--- a/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
+++ b/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
@@ -48,6 +48,22 @@ function getWidgetProps(widget: WidgetState) {
   }
   return {};
 }
+
+function handleCreateWidget(payload: CreateWidgetPayload) {
+  emit('create-widget', payload);
+}
+
+function handleUpdateConfig(payload: { id: string; config: CustomWidgetConfig }) {
+  emit('update-config', payload);
+}
+
+function handleUpdateWidget(payload: UpdateWidgetPayload) {
+  emit('update-widget', payload);
+}
+
+function handleDeleteWidget(id: string) {
+  emit('delete-widget', id);
+}
 </script>
 
 <template>
@@ -66,10 +82,10 @@ function getWidgetProps(widget: WidgetState) {
       <component
         :is="componentMap[widget.component] ?? componentMap.EncounterTimeline"
         v-bind="getWidgetProps(widget)"
-        @create-widget="(payload) => emit('create-widget', payload)"
-        @update-config="(payload) => emit('update-config', payload)"
-        @update-widget="(payload) => emit('update-widget', payload)"
-        @delete-widget="(id) => emit('delete-widget', id)"
+        @create-widget="handleCreateWidget"
+        @update-config="handleUpdateConfig"
+        @update-widget="handleUpdateWidget"
+        @delete-widget="handleDeleteWidget"
       />
     </DraggableWidget>
   </section>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,28 @@ importers:
         specifier: ^5.0.0
         version: 5.8.3
 
+  apps/daggerheart-dm-screen:
+    dependencies:
+      vue:
+        specifier: ^3.5.18
+        version: 3.5.21(typescript@5.8.3)
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@7.1.6(@types/node@20.19.17)(jiti@2.5.1)(lightningcss@1.30.1))(vue@3.5.21(typescript@5.8.3))
+      '@vue/tsconfig':
+        specifier: ^0.7.0
+        version: 0.7.0(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3))
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^7.1.2
+        version: 7.1.6(@types/node@20.19.17)(jiti@2.5.1)(lightningcss@1.30.1)
+      vue-tsc:
+        specifier: ^3.0.5
+        version: 3.0.7(typescript@5.8.3)
+
   apps/daggerheart-statblock-builder:
     dependencies:
       '@my-monorepo/theme':


### PR DESCRIPTION
## Summary
- add typed handler helpers in the DM screen widget board component
- wire the template to the typed handlers to avoid implicit any TypeScript errors

## Testing
- pnpm --filter daggerheart-dm-screen build

------
https://chatgpt.com/codex/tasks/task_e_68da5cfe9818832faa72e6219a17c557