### PR TITLE
Refine DM screen layout and styling

### DIFF
--- a/apps/daggerheart-dm-screen/src/App.vue
+++ b/apps/daggerheart-dm-screen/src/App.vue
@@ -5,7 +5,7 @@ import DMToolbar from './components/DMToolbar.vue';
 import type { CreateWidgetPayload, CustomWidgetConfig, UpdateWidgetPayload, WidgetState } from './types';
 import { createInitialWidgets } from './data/widgets';
 
-const GRID_SIZE = 40;
+const GRID_SIZE = 32;
 const MIN_WIDTH = GRID_SIZE * 5;
 const MIN_HEIGHT = GRID_SIZE * 4;
 
@@ -133,8 +133,8 @@ function getNextCustomPosition() {
   const index = nonPinned.length;
   const column = index % 3;
   const row = Math.floor(index / 3);
-  const baseX = snapToGrid(160 + column * 220);
-  const baseY = snapToGrid(160 + row * 220);
+  const baseX = snapToGrid(96 + column * (MIN_WIDTH + GRID_SIZE * 5));
+  const baseY = snapToGrid(96 + row * (MIN_HEIGHT + GRID_SIZE * 6));
   return { x: baseX, y: baseY };
 }
 
@@ -216,10 +216,10 @@ function resetLayout() {
 
 function cascadeWidgets() {
   const updated: WidgetState[] = [];
-  const gap = 28;
-  const columnWidth = 360;
-  const startX = 48;
-  const startY = 120;
+  const gap = GRID_SIZE * 0.75;
+  const columnWidth = MIN_WIDTH + GRID_SIZE * 5;
+  const startX = GRID_SIZE * 2;
+  const startY = GRID_SIZE * 3;
   let column = 0;
   let columnHeight = 0;
 
@@ -338,10 +338,7 @@ onBeforeUnmount(() => {
   position: relative;
   min-height: 100vh;
   overflow: hidden;
-  background: radial-gradient(circle at 12% 8%, rgba(100, 146, 255, 0.18), transparent 55%),
-    radial-gradient(circle at 85% 0%, rgba(255, 120, 221, 0.14), transparent 40%),
-    radial-gradient(circle at 50% 80%, rgba(95, 255, 198, 0.12), transparent 45%),
-    #05080f;
+  background: linear-gradient(180deg, #0d1726 0%, #0b1422 36%, #08101b 100%);
 }
 
 .app-shell--full {
@@ -351,36 +348,26 @@ onBeforeUnmount(() => {
 .aurora {
   position: absolute;
   inset: 0;
-  background: repeating-linear-gradient(
-      90deg,
-      transparent,
-      transparent 220px,
-      rgba(104, 150, 255, 0.03) 220px,
-      rgba(104, 150, 255, 0.03) 440px
-    ),
-    repeating-linear-gradient(
-      0deg,
-      transparent,
-      transparent 220px,
-      rgba(104, 150, 255, 0.03) 220px,
-      rgba(104, 150, 255, 0.03) 440px
-    );
-  mask: linear-gradient(180deg, rgba(5, 8, 15, 1) 0%, rgba(5, 8, 15, 0.45) 40%, rgba(5, 8, 15, 0) 100%);
+  background: radial-gradient(circle at 10% -10%, rgba(109, 173, 255, 0.28), transparent 55%),
+    radial-gradient(circle at 90% -20%, rgba(255, 176, 196, 0.22), transparent 50%),
+    radial-gradient(circle at 50% 80%, rgba(95, 255, 198, 0.18), transparent 55%);
+  opacity: 0.85;
+  filter: blur(6px) saturate(1.1);
   pointer-events: none;
 }
 
 .content {
   position: relative;
   z-index: 2;
-  padding: 48px clamp(32px, 4vw, 72px) 72px;
+  padding: 40px clamp(32px, 4vw, 68px) 64px;
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 24px;
 }
 
 .content--full {
   min-height: 100vh;
-  padding: 12px clamp(12px, 2vw, 32px) 32px;
+  padding: 16px clamp(16px, 2vw, 32px) 32px;
 }
 
 .content--full .board {
@@ -389,14 +376,14 @@ onBeforeUnmount(() => {
 
 @media (max-width: 900px) {
   .content {
-    padding: 32px clamp(20px, 5vw, 42px) 48px;
+    padding: 32px clamp(20px, 5vw, 42px) 44px;
   }
 }
 
 @media (max-width: 720px) {
   .content {
     padding: 24px 16px 32px;
-    gap: 24px;
+    gap: 20px;
   }
 
   .app-shell--phone .content {

--- a/apps/daggerheart-dm-screen/src/components/DMToolbar.vue
+++ b/apps/daggerheart-dm-screen/src/components/DMToolbar.vue
@@ -64,14 +64,14 @@ const emit = defineEmits<{
 .toolbar {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;
-  gap: 32px;
+  gap: 28px;
   align-items: center;
-  padding: 24px 32px;
-  background: linear-gradient(135deg, rgba(21, 36, 58, 0.82), rgba(10, 16, 28, 0.92));
-  border: 1px solid rgba(118, 174, 255, 0.2);
-  border-radius: 28px;
-  box-shadow: 0 24px 60px rgba(8, 18, 36, 0.65);
-  backdrop-filter: blur(18px);
+  padding: 20px 28px;
+  background: linear-gradient(135deg, rgba(25, 36, 54, 0.72), rgba(14, 22, 35, 0.9));
+  border: 1px solid rgba(138, 180, 235, 0.24);
+  border-radius: 26px;
+  box-shadow: 0 22px 56px rgba(6, 14, 28, 0.45);
+  backdrop-filter: blur(16px) saturate(1.05);
 }
 
 .identity {
@@ -95,21 +95,22 @@ const emit = defineEmits<{
 .glyph {
   display: grid;
   place-items: center;
-  width: 56px;
-  height: 56px;
-  border-radius: 18px;
-  background: linear-gradient(135deg, rgba(255, 167, 94, 0.65), rgba(255, 89, 141, 0.45));
-  font-size: 1.6rem;
-  box-shadow: inset 0 0 20px rgba(255, 255, 255, 0.15);
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 196, 121, 0.7), rgba(255, 115, 162, 0.48));
+  font-size: 1.55rem;
+  box-shadow: inset 0 0 16px rgba(255, 255, 255, 0.18);
 }
 
 .metrics {
   display: flex;
-  gap: 24px;
-  padding: 12px 20px;
-  border-radius: 18px;
-  background: rgba(13, 22, 36, 0.7);
-  border: 1px solid rgba(104, 150, 255, 0.2);
+  gap: 20px;
+  padding: 10px 18px;
+  border-radius: 16px;
+  background: rgba(20, 30, 46, 0.62);
+  border: 1px solid rgba(138, 180, 235, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(138, 180, 235, 0.08);
 }
 
 .metric {
@@ -134,8 +135,8 @@ const emit = defineEmits<{
   align-self: center;
   padding: 6px 12px;
   border-radius: 999px;
-  border: 1px solid rgba(118, 174, 255, 0.35);
-  background: rgba(12, 21, 33, 0.6);
+  border: 1px solid rgba(138, 180, 235, 0.35);
+  background: rgba(18, 30, 46, 0.65);
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -149,11 +150,11 @@ const emit = defineEmits<{
 
 button {
   border-radius: 999px;
-  padding: 12px 22px;
+  padding: 11px 20px;
   border: 1px solid transparent;
   cursor: pointer;
   letter-spacing: 0.04em;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
 button:focus-visible {
@@ -162,20 +163,20 @@ button:focus-visible {
 }
 
 button.ghost {
-  background: rgba(12, 21, 33, 0.75);
-  border-color: rgba(118, 174, 255, 0.35);
-  color: #e6f1ff;
+  background: rgba(22, 32, 48, 0.7);
+  border-color: rgba(138, 180, 235, 0.35);
+  color: #e8f1ff;
 }
 
 .ghost[aria-pressed='true'] {
-  background: rgba(118, 174, 255, 0.25);
-  border-color: rgba(118, 174, 255, 0.65);
+  background: rgba(138, 180, 235, 0.22);
+  border-color: rgba(138, 180, 235, 0.6);
 }
 
 button.primary {
-  background: linear-gradient(135deg, rgba(118, 174, 255, 0.9), rgba(94, 219, 255, 0.65));
+  background: linear-gradient(135deg, rgba(132, 192, 255, 0.92), rgba(108, 212, 255, 0.68));
   color: #041220;
-  box-shadow: 0 12px 30px rgba(66, 149, 255, 0.35);
+  box-shadow: 0 12px 30px rgba(80, 170, 255, 0.32);
 }
 
 button:hover {

--- a/apps/daggerheart-dm-screen/src/components/DraggableWidget.vue
+++ b/apps/daggerheart-dm-screen/src/components/DraggableWidget.vue
@@ -7,6 +7,9 @@ const props = defineProps<{
   disableInteractions?: boolean;
 }>();
 
+const MIN_WIDTH = 160;
+const MIN_HEIGHT = 128;
+
 const emit = defineEmits<{
   (e: 'dragging', payload: { id: string; x: number; y: number }): void;
   (e: 'focus'): void;
@@ -147,10 +150,10 @@ function onResizePointerMove(event: PointerEvent) {
   const board = element?.parentElement as HTMLElement | null;
 
   if (board) {
-    const maxWidth = Math.max(board.clientWidth - props.widget.position.x, 120);
-    const maxHeight = Math.max(board.clientHeight - props.widget.position.y, 120);
-    nextWidth = Math.min(Math.max(nextWidth, 200), maxWidth);
-    nextHeight = Math.min(Math.max(nextHeight, 160), maxHeight);
+    const maxWidth = Math.max(board.clientWidth - props.widget.position.x, MIN_WIDTH);
+    const maxHeight = Math.max(board.clientHeight - props.widget.position.y, MIN_HEIGHT);
+    nextWidth = Math.min(Math.max(nextWidth, MIN_WIDTH), maxWidth);
+    nextHeight = Math.min(Math.max(nextHeight, MIN_HEIGHT), maxHeight);
   }
 
   emit('resizing', {
@@ -231,28 +234,32 @@ onBeforeUnmount(() => {
   position: absolute;
   display: flex;
   flex-direction: column;
-  border-radius: 24px;
-  background: var(--surface);
-  border: 1px solid rgba(120, 182, 255, 0.18);
-  box-shadow: 0 22px 60px rgba(6, 16, 32, 0.6), inset 0 0 0 1px rgba(120, 182, 255, 0.16);
+  border-radius: 22px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), var(--surface));
+  border: 1px solid rgba(138, 180, 235, 0.22);
+  box-shadow: 0 18px 52px rgba(7, 15, 29, 0.45);
   color: inherit;
-  backdrop-filter: blur(14px);
+  backdrop-filter: blur(16px) saturate(1.05);
   overflow: hidden;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  transition: box-shadow 0.24s ease, transform 0.24s ease;
 }
 
 .widget::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: var(--accent);
-  opacity: 0.32;
+  background: radial-gradient(circle at top, color-mix(in srgb, var(--accent) 65%, transparent) 0%, transparent 68%);
+  opacity: 0.18;
   pointer-events: none;
   mix-blend-mode: screen;
 }
 
+.widget:hover {
+  box-shadow: 0 22px 60px rgba(6, 13, 26, 0.5);
+}
+
 .widget.pinned {
-  box-shadow: 0 14px 40px rgba(5, 14, 28, 0.4), inset 0 0 0 1px rgba(120, 182, 255, 0.32);
+  box-shadow: 0 16px 48px rgba(5, 12, 24, 0.38);
 }
 
 .widget.disabled {
@@ -263,11 +270,13 @@ onBeforeUnmount(() => {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 16px;
-  padding: 18px 20px 14px;
+  gap: 14px;
+  padding: 16px 18px 12px;
   cursor: grab;
   position: relative;
   z-index: 2;
+  background: color-mix(in srgb, var(--surface-strong) 82%, transparent);
+  border-bottom: 1px solid rgba(138, 180, 235, 0.18);
 }
 
 .widget.pinned .widget__header {
@@ -277,53 +286,59 @@ onBeforeUnmount(() => {
 .icon {
   display: grid;
   place-items: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 16px;
-  background: rgba(5, 12, 24, 0.6);
-  box-shadow: inset 0 0 12px rgba(255, 255, 255, 0.12);
-  font-size: 1.6rem;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--accent) 40%, rgba(15, 26, 40, 0.82));
+  box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.15);
+  font-size: 1.45rem;
 }
 
 .meta h2 {
   margin: 0 0 4px;
-  font-size: 1.1rem;
-  letter-spacing: 0.06em;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
 .meta p {
   margin: 0;
   color: var(--text-secondary);
-  font-size: 0.85rem;
+  font-size: 0.87rem;
 }
 
 .pin {
-  background: rgba(8, 16, 30, 0.7);
-  border: 1px solid rgba(120, 182, 255, 0.4);
+  background: rgba(22, 32, 48, 0.72);
+  border: 1px solid rgba(138, 180, 235, 0.4);
   border-radius: 999px;
   padding: 8px 16px;
-  color: rgba(220, 236, 255, 0.9);
+  color: rgba(229, 239, 255, 0.92);
   cursor: pointer;
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .pin[aria-pressed='true'] {
-  background: rgba(120, 182, 255, 0.24);
+  background: rgba(138, 180, 235, 0.24);
+  border-color: rgba(138, 180, 235, 0.6);
 }
 
 .pin:focus-visible {
-  outline: 2px solid rgba(134, 198, 255, 0.8);
+  outline: 2px solid rgba(150, 198, 255, 0.82);
   outline-offset: 2px;
+}
+
+.pin:hover {
+  transform: translateY(-1px);
 }
 
 .widget__body {
   position: relative;
   z-index: 1;
   flex: 1;
-  padding: 0 20px 20px;
+  padding: 2px 18px 18px;
   overflow: hidden;
 }
 
@@ -337,15 +352,15 @@ onBeforeUnmount(() => {
 
 .resize-handle {
   position: absolute;
-  width: 20px;
-  height: 20px;
-  right: 8px;
-  bottom: 8px;
-  border-radius: 4px;
-  background: rgba(118, 174, 255, 0.45);
-  border: 1px solid rgba(118, 174, 255, 0.7);
+  width: 18px;
+  height: 18px;
+  right: 10px;
+  bottom: 10px;
+  border-radius: 6px;
+  background: rgba(148, 190, 255, 0.55);
+  border: 1px solid rgba(148, 190, 255, 0.75);
   cursor: se-resize;
-  box-shadow: 0 4px 12px rgba(6, 16, 32, 0.45);
+  box-shadow: 0 4px 14px rgba(7, 14, 26, 0.45);
   opacity: 0;
   transition: opacity 0.2s ease;
 }
@@ -365,11 +380,12 @@ onBeforeUnmount(() => {
   }
 
   .widget::before {
-    opacity: 0.18;
+    opacity: 0.12;
   }
 
   .widget__header {
     cursor: default;
+    border-bottom-color: transparent;
   }
 
   .resize-handle {

--- a/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
+++ b/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
@@ -94,12 +94,19 @@ function handleDeleteWidget(id: string) {
 <style scoped>
 .board {
   position: relative;
-  min-height: 740px;
-  border-radius: 32px;
-  border: 1px solid rgba(104, 150, 255, 0.25);
-  background: linear-gradient(180deg, rgba(7, 12, 22, 0.82), rgba(7, 12, 22, 0.96));
+  min-height: 680px;
+  border-radius: 26px;
+  border: 1px solid var(--surface-border);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), var(--surface-strong));
+  box-shadow: 0 26px 60px rgba(7, 14, 26, 0.38);
   overflow: hidden;
-  padding: 32px;
+  padding: 26px 28px;
+  transition: box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.board:hover {
+  border-color: rgba(150, 190, 245, 0.28);
+  box-shadow: 0 32px 70px rgba(6, 13, 24, 0.42);
 }
 
 .board--mobile {
@@ -108,34 +115,35 @@ function handleDeleteWidget(id: string) {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  box-shadow: none;
 }
 
 .grid-surface {
   position: absolute;
   inset: 0;
-  background-image: linear-gradient(rgba(96, 144, 255, 0.12) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(96, 144, 255, 0.08) 1px, transparent 1px);
-  background-size: 120px 120px;
-  opacity: 0.4;
+  background-image: linear-gradient(rgba(130, 165, 220, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(130, 165, 220, 0.08) 1px, transparent 1px);
+  background-size: 96px 96px;
+  opacity: 0.35;
   pointer-events: none;
 }
 
 @media (max-width: 900px) {
   .board {
-    padding: 28px;
-    min-height: 640px;
+    padding: 24px;
+    min-height: 600px;
   }
 }
 
 @media (max-width: 720px) {
   .board {
-    border-radius: 24px;
+    border-radius: 22px;
     border-width: 1px;
   }
 
   .grid-surface {
-    opacity: 0.25;
-    background-size: 80px 80px;
+    opacity: 0.22;
+    background-size: 72px 72px;
   }
 }
 </style>

--- a/apps/daggerheart-dm-screen/src/style.css
+++ b/apps/daggerheart-dm-screen/src/style.css
@@ -1,14 +1,14 @@
 :root {
   color-scheme: dark;
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  background: radial-gradient(circle at top left, #1d2b3a, #0c1016 55%, #05070a);
-  color: #f5f7fb;
-  --surface: rgba(13, 22, 33, 0.9);
-  --surface-strong: rgba(24, 36, 50, 0.95);
-  --surface-border: rgba(105, 144, 195, 0.35);
-  --accent-glow: rgba(68, 169, 255, 0.35);
-  --text-secondary: rgba(223, 230, 244, 0.7);
-  --grid-line: rgba(107, 142, 186, 0.08);
+  background: linear-gradient(180deg, #101b2d 0%, #0c1625 40%, #0a1421 100%);
+  color: #f4f6fb;
+  --surface: rgba(17, 28, 42, 0.86);
+  --surface-strong: rgba(24, 36, 52, 0.92);
+  --surface-border: rgba(138, 180, 235, 0.22);
+  --accent-glow: rgba(92, 178, 255, 0.28);
+  --text-secondary: rgba(220, 228, 240, 0.72);
+  --grid-line: rgba(118, 156, 206, 0.12);
 }
 
 * {


### PR DESCRIPTION
## Summary
- shrink the widget grid sizing to allow denser layouts and update cascade spacing to match the smaller grid
- soften the application chrome with lighter gradients and refreshed toolbar, board, and widget treatments
- tune draggable widget interactions with new minimum sizes and more responsive resize handles

## Testing
- pnpm --filter daggerheart-dm-screen build

------
https://chatgpt.com/codex/tasks/task_e_68da5e330ba8832fab41a05289bfd262