### PR TITLE
Improve DM screen layout and interactions

### DIFF
--- a/apps/daggerheart-dm-screen/src/components/DraggableWidget.vue
+++ b/apps/daggerheart-dm-screen/src/components/DraggableWidget.vue
@@ -35,6 +35,13 @@ function interactionsDisabled() {
   return Boolean(props.disableInteractions);
 }
 
+function getBoardCanvas(element: HTMLElement | null) {
+  if (!element) {
+    return null;
+  }
+  return element.closest<HTMLElement>('[data-board-canvas]') ?? element.parentElement;
+}
+
 function onPointerDown(event: PointerEvent) {
   emit('focus');
 
@@ -53,6 +60,8 @@ function onPointerDown(event: PointerEvent) {
   startPointerY = event.clientY;
   startX = props.widget.position.x;
   startY = props.widget.position.y;
+
+  element.classList.add('is-dragging');
 
   element.setPointerCapture(pointerId);
   element.addEventListener('lostpointercapture', cleanup, { once: true });
@@ -73,7 +82,7 @@ function onPointerMove(event: PointerEvent) {
   let nextY = startY + deltaY;
 
   const element = root.value;
-  const board = element?.parentElement as HTMLElement | null;
+  const board = getBoardCanvas(element);
 
   if (board) {
     const maxX = Math.max(board.clientWidth - props.widget.size.width, 0);
@@ -104,6 +113,7 @@ function cleanup() {
   }
   isDragging = false;
   pointerId = null;
+  element?.classList.remove('is-dragging');
   window.removeEventListener('pointermove', onPointerMove);
 }
 
@@ -133,6 +143,8 @@ function onResizePointerDown(event: PointerEvent) {
 
   window.addEventListener('pointermove', onResizePointerMove);
   window.addEventListener('pointerup', onResizePointerUp, { once: true });
+
+  root.value?.classList.add('is-resizing');
 }
 
 function onResizePointerMove(event: PointerEvent) {
@@ -147,7 +159,7 @@ function onResizePointerMove(event: PointerEvent) {
   let nextHeight = startHeight + deltaY;
 
   const element = root.value;
-  const board = element?.parentElement as HTMLElement | null;
+  const board = getBoardCanvas(element);
 
   if (board) {
     const maxWidth = Math.max(board.clientWidth - props.widget.position.x, MIN_WIDTH);
@@ -179,6 +191,7 @@ function cleanupResize() {
   isResizing = false;
   resizePointerId = null;
   resizeHandleEl = null;
+  root.value?.classList.remove('is-resizing');
 }
 
 onBeforeUnmount(() => {
@@ -260,6 +273,16 @@ onBeforeUnmount(() => {
 
 .widget.pinned {
   box-shadow: 0 16px 48px rgba(5, 12, 24, 0.38);
+}
+
+.widget.is-dragging,
+.widget.is-resizing {
+  box-shadow: 0 28px 70px rgba(6, 13, 26, 0.55);
+  transform: translateZ(0);
+}
+
+.widget.is-dragging .widget__header {
+  cursor: grabbing;
 }
 
 .widget.disabled {
@@ -352,10 +375,10 @@ onBeforeUnmount(() => {
 
 .resize-handle {
   position: absolute;
-  width: 18px;
-  height: 18px;
-  right: 10px;
-  bottom: 10px;
+  width: 22px;
+  height: 22px;
+  right: 12px;
+  bottom: 12px;
   border-radius: 6px;
   background: rgba(148, 190, 255, 0.55);
   border: 1px solid rgba(148, 190, 255, 0.75);

--- a/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
+++ b/apps/daggerheart-dm-screen/src/components/WidgetBoard.vue
@@ -25,6 +25,7 @@ const componentMap: Record<string, Component> = {
 const props = defineProps<{
   widgets: WidgetState[];
   disableInteractions?: boolean;
+  canvasSize: { width: number; height: number };
 }>();
 
 const emit = defineEmits<{
@@ -68,26 +69,58 @@ function handleDeleteWidget(id: string) {
 
 <template>
   <section class="board" :class="{ 'board--mobile': props.disableInteractions }" aria-label="Daggerheart control board">
-    <div class="grid-surface" aria-hidden="true"></div>
-    <DraggableWidget
-      v-for="widget in props.widgets"
-      :key="widget.id"
-      :widget="widget"
-      :disable-interactions="props.disableInteractions"
-      @dragging="(payload) => emit('update:position', payload)"
-      @resizing="(payload) => emit('update:size', payload)"
-      @focus="emit('focus', widget.id)"
-      @toggle-pin="emit('toggle-pin', widget.id)"
+    <div
+      v-if="!props.disableInteractions"
+      class="board__canvas"
+      data-board-canvas
+      :style="{
+        width: `${Math.max(props.canvasSize.width, 0)}px`,
+        height: `${Math.max(props.canvasSize.height, 0)}px`
+      }"
     >
-      <component
-        :is="componentMap[widget.component] ?? componentMap.EncounterTimeline"
-        v-bind="getWidgetProps(widget)"
-        @create-widget="handleCreateWidget"
-        @update-config="handleUpdateConfig"
-        @update-widget="handleUpdateWidget"
-        @delete-widget="handleDeleteWidget"
-      />
-    </DraggableWidget>
+      <div class="grid-surface" aria-hidden="true"></div>
+      <DraggableWidget
+        v-for="widget in props.widgets"
+        :key="widget.id"
+        :widget="widget"
+        :disable-interactions="props.disableInteractions"
+        @dragging="(payload) => emit('update:position', payload)"
+        @resizing="(payload) => emit('update:size', payload)"
+        @focus="emit('focus', widget.id)"
+        @toggle-pin="emit('toggle-pin', widget.id)"
+      >
+        <component
+          :is="componentMap[widget.component] ?? componentMap.EncounterTimeline"
+          v-bind="getWidgetProps(widget)"
+          @create-widget="handleCreateWidget"
+          @update-config="handleUpdateConfig"
+          @update-widget="handleUpdateWidget"
+          @delete-widget="handleDeleteWidget"
+        />
+      </DraggableWidget>
+    </div>
+    <template v-else>
+      <div class="grid-surface" aria-hidden="true"></div>
+      <DraggableWidget
+        v-for="widget in props.widgets"
+        :key="widget.id"
+        :widget="widget"
+        :disable-interactions="props.disableInteractions"
+        @dragging="(payload) => emit('update:position', payload)"
+        @resizing="(payload) => emit('update:size', payload)"
+        @focus="emit('focus', widget.id)"
+        @toggle-pin="emit('toggle-pin', widget.id)"
+      >
+        <component
+          :is="componentMap[widget.component] ?? componentMap.EncounterTimeline"
+          v-bind="getWidgetProps(widget)"
+          @create-widget="handleCreateWidget"
+          @update-config="handleUpdateConfig"
+          @update-widget="handleUpdateWidget"
+          @delete-widget="handleDeleteWidget"
+        />
+      </DraggableWidget>
+    </template>
   </section>
 </template>
 
@@ -99,7 +132,7 @@ function handleDeleteWidget(id: string) {
   border: 1px solid var(--surface-border);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), var(--surface-strong));
   box-shadow: 0 26px 60px rgba(7, 14, 26, 0.38);
-  overflow: hidden;
+  overflow: auto;
   padding: 26px 28px;
   transition: box-shadow 0.25s ease, border-color 0.25s ease;
 }
@@ -116,6 +149,12 @@ function handleDeleteWidget(id: string) {
   flex-direction: column;
   gap: 16px;
   box-shadow: none;
+  overflow: visible;
+}
+
+.board__canvas {
+  position: relative;
+  min-width: 100%;
 }
 
 .grid-surface {
@@ -139,6 +178,12 @@ function handleDeleteWidget(id: string) {
   .board {
     border-radius: 22px;
     border-width: 1px;
+  }
+
+  .board__canvas {
+    min-width: 0;
+    width: 100% !important;
+    height: auto !important;
   }
 
   .grid-surface {


### PR DESCRIPTION
## Summary
- prevent widgets from overlapping by resolving positions and sizes on move, resize, and creation
- compute a dynamic board canvas and allow horizontal scrolling while preserving the stacked phone layout
- refine draggable widget feedback with clearer drag/resizing states and an enlarged resize handle

## Testing
- pnpm --filter daggerheart-dm-screen build

------
https://chatgpt.com/codex/tasks/task_e_68da80fba378832facdf944a6caad127